### PR TITLE
allow brackets in expression_value nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -100,16 +100,19 @@ module.exports = grammar({
 
     expression: $ => seq(
       '{',
-      $.expression_value,
-      '}'
+      prec.left(
+        seq(
+          alias(repeat($._expression_value), $.expression_value),
+          '}'
+        )
+      )
     ),
 
-    expression_value: $ => choice(
+    _expression_value: $ => choice(
       /[^{}]+/,
-      '{}',
       seq(
         '{',
-        alias($.expression_value, 'expression_value'),
+        optional($._expression_value),
         '}'
       ),
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -290,25 +290,38 @@
           "value": "{"
         },
         {
-          "type": "SYMBOL",
-          "name": "expression_value"
-        },
-        {
-          "type": "STRING",
-          "value": "}"
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression_value"
+                  }
+                },
+                "named": true,
+                "value": "expression_value"
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          }
         }
       ]
     },
-    "expression_value": {
+    "_expression_value": {
       "type": "CHOICE",
       "members": [
         {
           "type": "PATTERN",
           "value": "[^{}]+"
-        },
-        {
-          "type": "STRING",
-          "value": "{}"
         },
         {
           "type": "SEQ",
@@ -318,13 +331,16 @@
               "value": "{"
             },
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "expression_value"
-              },
-              "named": false,
-              "value": "expression_value"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression_value"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -134,7 +134,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "expression_value",
@@ -423,10 +423,6 @@
   },
   {
     "type": "{",
-    "named": false
-  },
-  {
-    "type": "{}",
     "named": false
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,15 +6,15 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 63
+#define STATE_COUNT 70
 #define LARGE_STATE_COUNT 2
 #define SYMBOL_COUNT 49
 #define ALIAS_COUNT 1
-#define TOKEN_COUNT 29
+#define TOKEN_COUNT 28
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
-#define PRODUCTION_ID_COUNT 3
+#define PRODUCTION_ID_COUNT 2
 
 enum {
   anon_sym_LT_BANG = 1,
@@ -26,46 +26,46 @@ enum {
   anon_sym_SLASH_GT = 7,
   anon_sym_LBRACE = 8,
   anon_sym_RBRACE = 9,
-  aux_sym_expression_value_token1 = 10,
-  anon_sym_LBRACE_RBRACE = 11,
-  anon_sym_EQ = 12,
-  sym_attribute_value = 13,
-  anon_sym_SQUOTE = 14,
-  aux_sym_quoted_attribute_value_token1 = 15,
-  anon_sym_DQUOTE = 16,
-  aux_sym_quoted_attribute_value_token2 = 17,
-  anon_sym_LT_PERCENT = 18,
-  anon_sym_LT_PERCENT_EQ = 19,
-  anon_sym_LT_PERCENT_PERCENT = 20,
-  anon_sym_LT_PERCENT_PERCENT_EQ = 21,
-  aux_sym_directive_token1 = 22,
-  anon_sym_PERCENT_GT = 23,
-  anon_sym_LT_PERCENT_POUND = 24,
-  sym_tag_name = 25,
-  sym_component_name = 26,
-  sym_attribute_name = 27,
-  sym_text = 28,
-  sym_fragment = 29,
-  sym__node = 30,
-  sym_doctype = 31,
-  sym_tag = 32,
-  sym_component = 33,
-  sym_start_tag = 34,
-  sym_end_tag = 35,
-  sym_self_closing_tag = 36,
-  sym_start_component = 37,
-  sym_end_component = 38,
-  sym_self_closing_component = 39,
-  sym_expression = 40,
-  sym_expression_value = 41,
-  sym_attribute = 42,
-  sym_quoted_attribute_value = 43,
-  sym_directive = 44,
-  sym_comment = 45,
-  aux_sym_fragment_repeat1 = 46,
-  aux_sym_start_tag_repeat1 = 47,
+  aux_sym__expression_value_token1 = 10,
+  anon_sym_EQ = 11,
+  sym_attribute_value = 12,
+  anon_sym_SQUOTE = 13,
+  aux_sym_quoted_attribute_value_token1 = 14,
+  anon_sym_DQUOTE = 15,
+  aux_sym_quoted_attribute_value_token2 = 16,
+  anon_sym_LT_PERCENT = 17,
+  anon_sym_LT_PERCENT_EQ = 18,
+  anon_sym_LT_PERCENT_PERCENT = 19,
+  anon_sym_LT_PERCENT_PERCENT_EQ = 20,
+  aux_sym_directive_token1 = 21,
+  anon_sym_PERCENT_GT = 22,
+  anon_sym_LT_PERCENT_POUND = 23,
+  sym_tag_name = 24,
+  sym_component_name = 25,
+  sym_attribute_name = 26,
+  sym_text = 27,
+  sym_fragment = 28,
+  sym__node = 29,
+  sym_doctype = 30,
+  sym_tag = 31,
+  sym_component = 32,
+  sym_start_tag = 33,
+  sym_end_tag = 34,
+  sym_self_closing_tag = 35,
+  sym_start_component = 36,
+  sym_end_component = 37,
+  sym_self_closing_component = 38,
+  sym_expression = 39,
+  sym__expression_value = 40,
+  sym_attribute = 41,
+  sym_quoted_attribute_value = 42,
+  sym_directive = 43,
+  sym_comment = 44,
+  aux_sym_fragment_repeat1 = 45,
+  aux_sym_start_tag_repeat1 = 46,
+  aux_sym_expression_repeat1 = 47,
   aux_sym_directive_repeat1 = 48,
-  anon_alias_sym_expression_value = 49,
+  alias_sym_expression_value = 49,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -79,8 +79,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_SLASH_GT] = "/>",
   [anon_sym_LBRACE] = "{",
   [anon_sym_RBRACE] = "}",
-  [aux_sym_expression_value_token1] = "expression_value_token1",
-  [anon_sym_LBRACE_RBRACE] = "{}",
+  [aux_sym__expression_value_token1] = "_expression_value_token1",
   [anon_sym_EQ] = "=",
   [sym_attribute_value] = "attribute_value",
   [anon_sym_SQUOTE] = "'",
@@ -110,15 +109,16 @@ static const char * const ts_symbol_names[] = {
   [sym_end_component] = "end_component",
   [sym_self_closing_component] = "self_closing_component",
   [sym_expression] = "expression",
-  [sym_expression_value] = "expression_value",
+  [sym__expression_value] = "_expression_value",
   [sym_attribute] = "attribute",
   [sym_quoted_attribute_value] = "quoted_attribute_value",
   [sym_directive] = "directive",
   [sym_comment] = "comment",
   [aux_sym_fragment_repeat1] = "fragment_repeat1",
   [aux_sym_start_tag_repeat1] = "start_tag_repeat1",
+  [aux_sym_expression_repeat1] = "expression_repeat1",
   [aux_sym_directive_repeat1] = "directive_repeat1",
-  [anon_alias_sym_expression_value] = "expression_value",
+  [alias_sym_expression_value] = "expression_value",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -132,8 +132,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_SLASH_GT] = anon_sym_SLASH_GT,
   [anon_sym_LBRACE] = anon_sym_LBRACE,
   [anon_sym_RBRACE] = anon_sym_RBRACE,
-  [aux_sym_expression_value_token1] = aux_sym_expression_value_token1,
-  [anon_sym_LBRACE_RBRACE] = anon_sym_LBRACE_RBRACE,
+  [aux_sym__expression_value_token1] = aux_sym__expression_value_token1,
   [anon_sym_EQ] = anon_sym_EQ,
   [sym_attribute_value] = sym_attribute_value,
   [anon_sym_SQUOTE] = anon_sym_SQUOTE,
@@ -163,15 +162,16 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_end_component] = sym_end_component,
   [sym_self_closing_component] = sym_self_closing_component,
   [sym_expression] = sym_expression,
-  [sym_expression_value] = sym_expression_value,
+  [sym__expression_value] = sym__expression_value,
   [sym_attribute] = sym_attribute,
   [sym_quoted_attribute_value] = sym_quoted_attribute_value,
   [sym_directive] = sym_directive,
   [sym_comment] = sym_comment,
   [aux_sym_fragment_repeat1] = aux_sym_fragment_repeat1,
   [aux_sym_start_tag_repeat1] = aux_sym_start_tag_repeat1,
+  [aux_sym_expression_repeat1] = aux_sym_expression_repeat1,
   [aux_sym_directive_repeat1] = aux_sym_directive_repeat1,
-  [anon_alias_sym_expression_value] = anon_alias_sym_expression_value,
+  [alias_sym_expression_value] = alias_sym_expression_value,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -215,12 +215,8 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_expression_value_token1] = {
+  [aux_sym__expression_value_token1] = {
     .visible = false,
-    .named = false,
-  },
-  [anon_sym_LBRACE_RBRACE] = {
-    .visible = true,
     .named = false,
   },
   [anon_sym_EQ] = {
@@ -339,8 +335,8 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_expression_value] = {
-    .visible = true,
+  [sym__expression_value] = {
+    .visible = false,
     .named = true,
   },
   [sym_attribute] = {
@@ -367,33 +363,34 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_expression_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
   [aux_sym_directive_repeat1] = {
     .visible = false,
     .named = false,
   },
-  [anon_alias_sym_expression_value] = {
+  [alias_sym_expression_value] = {
     .visible = true,
-    .named = false,
+    .named = true,
   },
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
   [1] = {
-    [1] = sym_expression_value,
-  },
-  [2] = {
-    [1] = anon_alias_sym_expression_value,
+    [1] = alias_sym_expression_value,
   },
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
-  sym_expression_value, 2,
-    sym_expression_value,
-    anon_alias_sym_expression_value,
+  aux_sym_expression_repeat1, 2,
+    aux_sym_expression_repeat1,
+    alias_sym_expression_value,
   aux_sym_directive_repeat1, 2,
     aux_sym_directive_repeat1,
-    sym_expression_value,
+    alias_sym_expression_value,
   0,
 };
 
@@ -463,26 +460,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(23);
-      if (lookahead == '"') ADVANCE(43);
+      if (lookahead == '"') ADVANCE(41);
       if (lookahead == '%') ADVANCE(7);
-      if (lookahead == '\'') ADVANCE(40);
+      if (lookahead == '\'') ADVANCE(38);
       if (lookahead == '/') ADVANCE(8);
       if (lookahead == '<') ADVANCE(29);
-      if (lookahead == '=') ADVANCE(38);
+      if (lookahead == '=') ADVANCE(36);
       if (lookahead == '>') ADVANCE(28);
       if (lookahead == 'D') ADVANCE(11);
-      if (lookahead == 'h') ADVANCE(59);
-      if (lookahead == '{') ADVANCE(33);
-      if (lookahead == '}') ADVANCE(34);
+      if (lookahead == 'h') ADVANCE(57);
+      if (lookahead == '{') ADVANCE(32);
+      if (lookahead == '}') ADVANCE(33);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(43);
-      if (lookahead == '\'') ADVANCE(40);
+      if (lookahead == '"') ADVANCE(41);
+      if (lookahead == '\'') ADVANCE(38);
       if (lookahead == '{') ADVANCE(32);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
@@ -490,43 +487,43 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(1)
       if (lookahead != 0 &&
           (lookahead < '<' || '>' < lookahead) &&
-          lookahead != '}') ADVANCE(39);
+          lookahead != '}') ADVANCE(37);
       END_STATE();
     case 2:
-      if (lookahead == '"') ADVANCE(43);
+      if (lookahead == '"') ADVANCE(41);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(44);
-      if (lookahead != 0) ADVANCE(45);
+          lookahead == ' ') ADVANCE(42);
+      if (lookahead != 0) ADVANCE(43);
       END_STATE();
     case 3:
-      if (lookahead == '%') ADVANCE(53);
+      if (lookahead == '%') ADVANCE(51);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(51);
-      if (lookahead != 0) ADVANCE(54);
+          lookahead == ' ') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(52);
       END_STATE();
     case 4:
-      if (lookahead == '%') ADVANCE(50);
+      if (lookahead == '%') ADVANCE(48);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(52);
-      if (lookahead != 0) ADVANCE(54);
+          lookahead == ' ') ADVANCE(50);
+      if (lookahead != 0) ADVANCE(52);
       END_STATE();
     case 5:
-      if (lookahead == '\'') ADVANCE(40);
+      if (lookahead == '\'') ADVANCE(38);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(41);
-      if (lookahead != 0) ADVANCE(42);
+          lookahead == ' ') ADVANCE(39);
+      if (lookahead != 0) ADVANCE(40);
       END_STATE();
     case 6:
       if (lookahead == '/') ADVANCE(8);
-      if (lookahead == '=') ADVANCE(38);
+      if (lookahead == '=') ADVANCE(36);
       if (lookahead == '>') ADVANCE(28);
       if (lookahead == '{') ADVANCE(32);
       if (lookahead == '\t' ||
@@ -537,10 +534,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '"' &&
           lookahead != '\'' &&
           lookahead != '<' &&
-          lookahead != '}') ADVANCE(64);
+          lookahead != '}') ADVANCE(62);
       END_STATE();
     case 7:
-      if (lookahead == '>') ADVANCE(55);
+      if (lookahead == '>') ADVANCE(53);
       END_STATE();
     case 8:
       if (lookahead == '>') ADVANCE(31);
@@ -580,13 +577,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 't') ADVANCE(17);
       END_STATE();
     case 19:
-      if (lookahead == '{') ADVANCE(33);
+      if (lookahead == '{') ADVANCE(32);
+      if (lookahead == '}') ADVANCE(33);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
-      if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(36);
+          lookahead == ' ') ADVANCE(34);
+      if (lookahead != 0) ADVANCE(35);
       END_STATE();
     case 20:
       if (lookahead == '\t' ||
@@ -597,16 +594,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '<' &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(65);
+          lookahead != '}') ADVANCE(63);
       END_STATE();
     case 21:
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(21)
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
       if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(62);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(60);
       END_STATE();
     case 22:
       if (eof) ADVANCE(23);
@@ -618,7 +615,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(65);
+          lookahead != '}') ADVANCE(63);
       END_STATE();
     case 23:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -634,8 +631,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 27:
       ACCEPT_TOKEN(anon_sym_html);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(61);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(59);
       END_STATE();
     case 28:
       ACCEPT_TOKEN(anon_sym_GT);
@@ -643,7 +640,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 29:
       ACCEPT_TOKEN(anon_sym_LT);
       if (lookahead == '!') ADVANCE(24);
-      if (lookahead == '%') ADVANCE(46);
+      if (lookahead == '%') ADVANCE(44);
       if (lookahead == '/') ADVANCE(30);
       END_STATE();
     case 30:
@@ -656,166 +653,159 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
-      if (lookahead == '}') ADVANCE(37);
-      END_STATE();
-    case 34:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 35:
-      ACCEPT_TOKEN(aux_sym_expression_value_token1);
+    case 34:
+      ACCEPT_TOKEN(aux_sym__expression_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
+          lookahead == ' ') ADVANCE(34);
       if (lookahead != 0 &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(36);
+          lookahead != '}') ADVANCE(35);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(aux_sym__expression_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(35);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(aux_sym_expression_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(36);
-      END_STATE();
-    case 37:
-      ACCEPT_TOKEN(anon_sym_LBRACE_RBRACE);
-      END_STATE();
-    case 38:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
-    case 39:
+    case 37:
       ACCEPT_TOKEN(sym_attribute_value);
-      if (!sym_attribute_value_character_set_1(lookahead)) ADVANCE(39);
+      if (!sym_attribute_value_character_set_1(lookahead)) ADVANCE(37);
       END_STATE();
-    case 40:
+    case 38:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
-    case 41:
+    case 39:
       ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(41);
+          lookahead == ' ') ADVANCE(39);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(42);
+          lookahead != '\'') ADVANCE(40);
       END_STATE();
-    case 42:
+    case 40:
       ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(42);
+          lookahead != '\'') ADVANCE(40);
       END_STATE();
-    case 43:
+    case 41:
       ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
-    case 44:
+    case 42:
       ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(44);
+          lookahead == ' ') ADVANCE(42);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(45);
+          lookahead != '"') ADVANCE(43);
       END_STATE();
-    case 45:
+    case 43:
       ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(45);
+          lookahead != '"') ADVANCE(43);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
+      if (lookahead == '#') ADVANCE(54);
+      if (lookahead == '%') ADVANCE(46);
+      if (lookahead == '=') ADVANCE(45);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
       END_STATE();
     case 46:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
-      if (lookahead == '#') ADVANCE(56);
-      if (lookahead == '%') ADVANCE(48);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
       if (lookahead == '=') ADVANCE(47);
       END_STATE();
     case 47:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT_EQ);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
-      if (lookahead == '=') ADVANCE(49);
+      ACCEPT_TOKEN(aux_sym_directive_token1);
       END_STATE();
     case 49:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT_EQ);
+      ACCEPT_TOKEN(aux_sym_directive_token1);
+      if (lookahead == '%') ADVANCE(51);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(49);
+      if (lookahead != 0) ADVANCE(52);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_directive_token1);
+      if (lookahead == '%') ADVANCE(48);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(50);
+      if (lookahead != 0) ADVANCE(52);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead == '%') ADVANCE(53);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(51);
-      if (lookahead != 0) ADVANCE(54);
+      if (lookahead == '>') ADVANCE(53);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead == '%') ADVANCE(50);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(52);
-      if (lookahead != 0) ADVANCE(54);
+      if (lookahead != 0 &&
+          lookahead != '%') ADVANCE(52);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead == '>') ADVANCE(55);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead != 0 &&
-          lookahead != '%') ADVANCE(54);
-      END_STATE();
-    case 55:
       ACCEPT_TOKEN(anon_sym_PERCENT_GT);
       END_STATE();
-    case 56:
+    case 54:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'l') ADVANCE(27);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(59);
+      END_STATE();
+    case 56:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'm') ADVANCE(55);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(59);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(27);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(61);
+      if (lookahead == 't') ADVANCE(56);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(59);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(57);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(61);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(59);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(58);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(61);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(59);
       END_STATE();
     case 60:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(60);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(61);
+      ACCEPT_TOKEN(sym_component_name);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(60);
+      if (!sym_component_name_character_set_1(lookahead)) ADVANCE(61);
       END_STATE();
     case 61:
-      ACCEPT_TOKEN(sym_tag_name);
+      ACCEPT_TOKEN(sym_component_name);
       if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(61);
       END_STATE();
     case 62:
-      ACCEPT_TOKEN(sym_component_name);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(62);
-      if (!sym_component_name_character_set_1(lookahead)) ADVANCE(63);
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(62);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(sym_component_name);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(63);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(64);
-      END_STATE();
-    case 65:
       ACCEPT_TOKEN(sym_text);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
@@ -825,7 +815,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '<' &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(65);
+          lookahead != '}') ADVANCE(63);
       END_STATE();
     default:
       return false;
@@ -868,34 +858,41 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [32] = {.lex_state = 1},
   [33] = {.lex_state = 6},
   [34] = {.lex_state = 19},
-  [35] = {.lex_state = 6},
-  [36] = {.lex_state = 6},
-  [37] = {.lex_state = 6},
+  [35] = {.lex_state = 19},
+  [36] = {.lex_state = 19},
+  [37] = {.lex_state = 19},
   [38] = {.lex_state = 6},
-  [39] = {.lex_state = 19},
-  [40] = {.lex_state = 3},
-  [41] = {.lex_state = 3},
-  [42] = {.lex_state = 3},
-  [43] = {.lex_state = 3},
-  [44] = {.lex_state = 4},
-  [45] = {.lex_state = 4},
-  [46] = {.lex_state = 21},
-  [47] = {.lex_state = 5},
-  [48] = {.lex_state = 2},
-  [49] = {.lex_state = 21},
-  [50] = {.lex_state = 21},
-  [51] = {.lex_state = 0},
-  [52] = {.lex_state = 0},
-  [53] = {.lex_state = 15},
-  [54] = {.lex_state = 0},
-  [55] = {.lex_state = 0},
+  [39] = {.lex_state = 6},
+  [40] = {.lex_state = 6},
+  [41] = {.lex_state = 6},
+  [42] = {.lex_state = 19},
+  [43] = {.lex_state = 6},
+  [44] = {.lex_state = 3},
+  [45] = {.lex_state = 19},
+  [46] = {.lex_state = 19},
+  [47] = {.lex_state = 3},
+  [48] = {.lex_state = 19},
+  [49] = {.lex_state = 3},
+  [50] = {.lex_state = 4},
+  [51] = {.lex_state = 4},
+  [52] = {.lex_state = 21},
+  [53] = {.lex_state = 5},
+  [54] = {.lex_state = 2},
+  [55] = {.lex_state = 3},
   [56] = {.lex_state = 0},
   [57] = {.lex_state = 0},
   [58] = {.lex_state = 0},
   [59] = {.lex_state = 0},
   [60] = {.lex_state = 0},
-  [61] = {.lex_state = 0},
-  [62] = {.lex_state = 0},
+  [61] = {.lex_state = 15},
+  [62] = {.lex_state = 21},
+  [63] = {.lex_state = 0},
+  [64] = {.lex_state = 0},
+  [65] = {.lex_state = 21},
+  [66] = {.lex_state = 0},
+  [67] = {.lex_state = 0},
+  [68] = {.lex_state = 0},
+  [69] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -910,7 +907,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_SLASH_GT] = ACTIONS(1),
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
-    [anon_sym_LBRACE_RBRACE] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
     [anon_sym_SQUOTE] = ACTIONS(1),
     [anon_sym_DQUOTE] = ACTIONS(1),
@@ -923,7 +919,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_tag_name] = ACTIONS(1),
   },
   [1] = {
-    [sym_fragment] = STATE(54),
+    [sym_fragment] = STATE(60),
     [sym__node] = STATE(7),
     [sym_doctype] = STATE(7),
     [sym_tag] = STATE(7),
@@ -1001,7 +997,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_self_closing_tag,
     STATE(11), 1,
       sym_self_closing_component,
-    STATE(18), 1,
+    STATE(13), 1,
       sym_end_component,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1036,7 +1032,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_self_closing_tag,
     STATE(11), 1,
       sym_self_closing_component,
-    STATE(21), 1,
+    STATE(14), 1,
       sym_end_tag,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1071,7 +1067,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_self_closing_tag,
     STATE(11), 1,
       sym_self_closing_component,
-    STATE(22), 1,
+    STATE(20), 1,
       sym_end_component,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1106,7 +1102,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_self_closing_tag,
     STATE(11), 1,
       sym_self_closing_component,
-    STATE(19), 1,
+    STATE(18), 1,
       sym_end_tag,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1398,48 +1394,48 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_PERCENT_EQ,
       anon_sym_LT_PERCENT_POUND,
       sym_text,
-  [564] = 4,
-    ACTIONS(127), 1,
-      anon_sym_LBRACE,
-    ACTIONS(130), 1,
-      sym_attribute_name,
-    ACTIONS(125), 2,
+  [564] = 5,
+    ACTIONS(125), 1,
       anon_sym_GT,
+    ACTIONS(127), 1,
       anon_sym_SLASH_GT,
-    STATE(27), 3,
+    ACTIONS(129), 1,
+      anon_sym_LBRACE,
+    ACTIONS(131), 1,
+      sym_attribute_name,
+    STATE(28), 3,
       sym_expression,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [580] = 5,
-    ACTIONS(133), 1,
-      anon_sym_GT,
+  [582] = 4,
     ACTIONS(135), 1,
-      anon_sym_SLASH_GT,
-    ACTIONS(137), 1,
       anon_sym_LBRACE,
-    ACTIONS(139), 1,
+    ACTIONS(138), 1,
       sym_attribute_name,
-    STATE(31), 3,
+    ACTIONS(133), 2,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+    STATE(28), 3,
       sym_expression,
       sym_attribute,
       aux_sym_start_tag_repeat1,
   [598] = 5,
-    ACTIONS(137), 1,
+    ACTIONS(129), 1,
       anon_sym_LBRACE,
-    ACTIONS(139), 1,
+    ACTIONS(131), 1,
       sym_attribute_name,
     ACTIONS(141), 1,
       anon_sym_GT,
     ACTIONS(143), 1,
       anon_sym_SLASH_GT,
-    STATE(27), 3,
+    STATE(28), 3,
       sym_expression,
       sym_attribute,
       aux_sym_start_tag_repeat1,
   [616] = 5,
-    ACTIONS(137), 1,
+    ACTIONS(129), 1,
       anon_sym_LBRACE,
-    ACTIONS(139), 1,
+    ACTIONS(131), 1,
       sym_attribute_name,
     ACTIONS(145), 1,
       anon_sym_GT,
@@ -1450,9 +1446,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_attribute,
       aux_sym_start_tag_repeat1,
   [634] = 5,
-    ACTIONS(137), 1,
+    ACTIONS(129), 1,
       anon_sym_LBRACE,
-    ACTIONS(139), 1,
+    ACTIONS(131), 1,
       sym_attribute_name,
     ACTIONS(149), 1,
       anon_sym_GT,
@@ -1463,7 +1459,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_attribute,
       aux_sym_start_tag_repeat1,
   [652] = 5,
-    ACTIONS(137), 1,
+    ACTIONS(129), 1,
       anon_sym_LBRACE,
     ACTIONS(153), 1,
       sym_attribute_value,
@@ -1471,7 +1467,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
     ACTIONS(157), 1,
       anon_sym_DQUOTE,
-    STATE(37), 2,
+    STATE(40), 2,
       sym_expression,
       sym_quoted_attribute_value,
   [669] = 2,
@@ -1482,140 +1478,197 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SLASH_GT,
       anon_sym_LBRACE,
       sym_attribute_name,
-  [679] = 4,
+  [679] = 5,
     ACTIONS(163), 1,
       anon_sym_LBRACE,
-    ACTIONS(165), 1,
-      aux_sym_expression_value_token1,
-    ACTIONS(167), 1,
-      anon_sym_LBRACE_RBRACE,
-    STATE(52), 1,
-      sym_expression_value,
-  [692] = 1,
-    ACTIONS(169), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
+    ACTIONS(166), 1,
+      anon_sym_RBRACE,
+    ACTIONS(168), 1,
+      aux_sym__expression_value_token1,
+    STATE(34), 1,
+      aux_sym_expression_repeat1,
+    STATE(48), 1,
+      sym__expression_value,
+  [695] = 5,
+    ACTIONS(171), 1,
       anon_sym_LBRACE,
-      sym_attribute_name,
-  [699] = 1,
-    ACTIONS(171), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
+    ACTIONS(173), 1,
+      anon_sym_RBRACE,
+    ACTIONS(175), 1,
+      aux_sym__expression_value_token1,
+    STATE(34), 1,
+      aux_sym_expression_repeat1,
+    STATE(48), 1,
+      sym__expression_value,
+  [711] = 5,
+    ACTIONS(171), 1,
       anon_sym_LBRACE,
-      sym_attribute_name,
-  [706] = 1,
-    ACTIONS(173), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [713] = 1,
-    ACTIONS(175), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [720] = 4,
-    ACTIONS(163), 1,
-      anon_sym_LBRACE,
-    ACTIONS(165), 1,
-      aux_sym_expression_value_token1,
-    ACTIONS(167), 1,
-      anon_sym_LBRACE_RBRACE,
-    STATE(55), 1,
-      sym_expression_value,
-  [733] = 3,
+    ACTIONS(175), 1,
+      aux_sym__expression_value_token1,
     ACTIONS(177), 1,
-      aux_sym_directive_token1,
+      anon_sym_RBRACE,
+    STATE(35), 1,
+      aux_sym_expression_repeat1,
+    STATE(48), 1,
+      sym__expression_value,
+  [727] = 4,
     ACTIONS(179), 1,
-      anon_sym_PERCENT_GT,
-    STATE(41), 1,
-      aux_sym_directive_repeat1,
-  [743] = 3,
+      anon_sym_LBRACE,
     ACTIONS(181), 1,
-      aux_sym_directive_token1,
-    ACTIONS(184), 1,
-      anon_sym_PERCENT_GT,
-    STATE(41), 1,
-      aux_sym_directive_repeat1,
-  [753] = 3,
-    ACTIONS(177), 1,
-      aux_sym_directive_token1,
-    ACTIONS(186), 1,
-      anon_sym_PERCENT_GT,
-    STATE(41), 1,
-      aux_sym_directive_repeat1,
-  [763] = 1,
-    ACTIONS(188), 2,
-      aux_sym_directive_token1,
-      anon_sym_PERCENT_GT,
-  [768] = 2,
-    ACTIONS(190), 1,
-      aux_sym_directive_token1,
-    STATE(42), 1,
-      aux_sym_directive_repeat1,
-  [775] = 2,
-    ACTIONS(190), 1,
-      aux_sym_directive_token1,
-    STATE(40), 1,
-      aux_sym_directive_repeat1,
-  [782] = 2,
-    ACTIONS(192), 1,
-      sym_tag_name,
-    ACTIONS(194), 1,
-      sym_component_name,
-  [789] = 2,
-    ACTIONS(196), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(198), 1,
-      aux_sym_quoted_attribute_value_token1,
-  [796] = 2,
-    ACTIONS(196), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(200), 1,
-      aux_sym_quoted_attribute_value_token2,
-  [803] = 1,
-    ACTIONS(202), 1,
-      sym_component_name,
-  [807] = 1,
-    ACTIONS(204), 1,
-      sym_tag_name,
-  [811] = 1,
-    ACTIONS(206), 1,
       anon_sym_RBRACE,
-  [815] = 1,
-    ACTIONS(208), 1,
+    ACTIONS(183), 1,
+      aux_sym__expression_value_token1,
+    STATE(69), 1,
+      sym__expression_value,
+  [740] = 1,
+    ACTIONS(185), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [747] = 1,
+    ACTIONS(187), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [754] = 1,
+    ACTIONS(189), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [761] = 1,
+    ACTIONS(191), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [768] = 4,
+    ACTIONS(179), 1,
+      anon_sym_LBRACE,
+    ACTIONS(193), 1,
       anon_sym_RBRACE,
-  [819] = 1,
-    ACTIONS(210), 1,
-      anon_sym_html,
-  [823] = 1,
-    ACTIONS(212), 1,
-      ts_builtin_sym_end,
-  [827] = 1,
+    ACTIONS(195), 1,
+      aux_sym__expression_value_token1,
+    STATE(58), 1,
+      sym__expression_value,
+  [781] = 1,
+    ACTIONS(197), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [788] = 3,
+    ACTIONS(199), 1,
+      aux_sym_directive_token1,
+    ACTIONS(201), 1,
+      anon_sym_PERCENT_GT,
+    STATE(47), 1,
+      aux_sym_directive_repeat1,
+  [798] = 2,
+    ACTIONS(205), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(203), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [806] = 2,
+    ACTIONS(209), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(207), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [814] = 3,
+    ACTIONS(211), 1,
+      aux_sym_directive_token1,
     ACTIONS(214), 1,
-      anon_sym_RBRACE,
-  [831] = 1,
-    ACTIONS(216), 1,
-      anon_sym_DOCTYPE,
-  [835] = 1,
+      anon_sym_PERCENT_GT,
+    STATE(47), 1,
+      aux_sym_directive_repeat1,
+  [824] = 2,
     ACTIONS(218), 1,
-      anon_sym_GT,
-  [839] = 1,
-    ACTIONS(220), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(216), 2,
+      anon_sym_LBRACE,
       anon_sym_RBRACE,
-  [843] = 1,
+  [832] = 3,
+    ACTIONS(199), 1,
+      aux_sym_directive_token1,
+    ACTIONS(220), 1,
+      anon_sym_PERCENT_GT,
+    STATE(47), 1,
+      aux_sym_directive_repeat1,
+  [842] = 2,
     ACTIONS(222), 1,
-      anon_sym_GT,
-  [847] = 1,
+      aux_sym_directive_token1,
+    STATE(49), 1,
+      aux_sym_directive_repeat1,
+  [849] = 2,
+    ACTIONS(222), 1,
+      aux_sym_directive_token1,
+    STATE(44), 1,
+      aux_sym_directive_repeat1,
+  [856] = 2,
     ACTIONS(224), 1,
-      anon_sym_SQUOTE,
-  [851] = 1,
-    ACTIONS(224), 1,
-      anon_sym_DQUOTE,
-  [855] = 1,
+      sym_tag_name,
     ACTIONS(226), 1,
+      sym_component_name,
+  [863] = 2,
+    ACTIONS(228), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(230), 1,
+      aux_sym_quoted_attribute_value_token1,
+  [870] = 2,
+    ACTIONS(228), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(232), 1,
+      aux_sym_quoted_attribute_value_token2,
+  [877] = 1,
+    ACTIONS(234), 2,
+      aux_sym_directive_token1,
+      anon_sym_PERCENT_GT,
+  [882] = 1,
+    ACTIONS(236), 1,
       anon_sym_GT,
+  [886] = 1,
+    ACTIONS(238), 1,
+      anon_sym_GT,
+  [890] = 1,
+    ACTIONS(240), 1,
+      anon_sym_RBRACE,
+  [894] = 1,
+    ACTIONS(242), 1,
+      anon_sym_DOCTYPE,
+  [898] = 1,
+    ACTIONS(244), 1,
+      ts_builtin_sym_end,
+  [902] = 1,
+    ACTIONS(246), 1,
+      anon_sym_html,
+  [906] = 1,
+    ACTIONS(248), 1,
+      sym_tag_name,
+  [910] = 1,
+    ACTIONS(250), 1,
+      anon_sym_SQUOTE,
+  [914] = 1,
+    ACTIONS(250), 1,
+      anon_sym_DQUOTE,
+  [918] = 1,
+    ACTIONS(252), 1,
+      sym_component_name,
+  [922] = 1,
+    ACTIONS(205), 1,
+      anon_sym_RBRACE,
+  [926] = 1,
+    ACTIONS(209), 1,
+      anon_sym_RBRACE,
+  [930] = 1,
+    ACTIONS(254), 1,
+      anon_sym_GT,
+  [934] = 1,
+    ACTIONS(256), 1,
+      anon_sym_RBRACE,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
@@ -1645,154 +1698,175 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(25)] = 536,
   [SMALL_STATE(26)] = 550,
   [SMALL_STATE(27)] = 564,
-  [SMALL_STATE(28)] = 580,
+  [SMALL_STATE(28)] = 582,
   [SMALL_STATE(29)] = 598,
   [SMALL_STATE(30)] = 616,
   [SMALL_STATE(31)] = 634,
   [SMALL_STATE(32)] = 652,
   [SMALL_STATE(33)] = 669,
   [SMALL_STATE(34)] = 679,
-  [SMALL_STATE(35)] = 692,
-  [SMALL_STATE(36)] = 699,
-  [SMALL_STATE(37)] = 706,
-  [SMALL_STATE(38)] = 713,
-  [SMALL_STATE(39)] = 720,
-  [SMALL_STATE(40)] = 733,
-  [SMALL_STATE(41)] = 743,
-  [SMALL_STATE(42)] = 753,
-  [SMALL_STATE(43)] = 763,
-  [SMALL_STATE(44)] = 768,
-  [SMALL_STATE(45)] = 775,
-  [SMALL_STATE(46)] = 782,
-  [SMALL_STATE(47)] = 789,
-  [SMALL_STATE(48)] = 796,
-  [SMALL_STATE(49)] = 803,
-  [SMALL_STATE(50)] = 807,
-  [SMALL_STATE(51)] = 811,
-  [SMALL_STATE(52)] = 815,
-  [SMALL_STATE(53)] = 819,
-  [SMALL_STATE(54)] = 823,
-  [SMALL_STATE(55)] = 827,
-  [SMALL_STATE(56)] = 831,
-  [SMALL_STATE(57)] = 835,
-  [SMALL_STATE(58)] = 839,
-  [SMALL_STATE(59)] = 843,
-  [SMALL_STATE(60)] = 847,
-  [SMALL_STATE(61)] = 851,
-  [SMALL_STATE(62)] = 855,
+  [SMALL_STATE(35)] = 695,
+  [SMALL_STATE(36)] = 711,
+  [SMALL_STATE(37)] = 727,
+  [SMALL_STATE(38)] = 740,
+  [SMALL_STATE(39)] = 747,
+  [SMALL_STATE(40)] = 754,
+  [SMALL_STATE(41)] = 761,
+  [SMALL_STATE(42)] = 768,
+  [SMALL_STATE(43)] = 781,
+  [SMALL_STATE(44)] = 788,
+  [SMALL_STATE(45)] = 798,
+  [SMALL_STATE(46)] = 806,
+  [SMALL_STATE(47)] = 814,
+  [SMALL_STATE(48)] = 824,
+  [SMALL_STATE(49)] = 832,
+  [SMALL_STATE(50)] = 842,
+  [SMALL_STATE(51)] = 849,
+  [SMALL_STATE(52)] = 856,
+  [SMALL_STATE(53)] = 863,
+  [SMALL_STATE(54)] = 870,
+  [SMALL_STATE(55)] = 877,
+  [SMALL_STATE(56)] = 882,
+  [SMALL_STATE(57)] = 886,
+  [SMALL_STATE(58)] = 890,
+  [SMALL_STATE(59)] = 894,
+  [SMALL_STATE(60)] = 898,
+  [SMALL_STATE(61)] = 902,
+  [SMALL_STATE(62)] = 906,
+  [SMALL_STATE(63)] = 910,
+  [SMALL_STATE(64)] = 914,
+  [SMALL_STATE(65)] = 918,
+  [SMALL_STATE(66)] = 922,
+  [SMALL_STATE(67)] = 926,
+  [SMALL_STATE(68)] = 930,
+  [SMALL_STATE(69)] = 934,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 0),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
   [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
   [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
-  [19] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(56),
-  [22] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(46),
-  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(45),
-  [28] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(45),
-  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(44),
+  [19] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(59),
+  [22] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(52),
+  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(51),
+  [28] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(51),
+  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(50),
   [34] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(2),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
   [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
   [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
   [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
   [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1),
-  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3, .production_id = 1),
-  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3, .production_id = 1),
-  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3),
-  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_tag, 3),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4),
+  [51] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4),
+  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3),
+  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3),
   [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 1),
   [59] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 1),
   [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 1),
   [63] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 1),
-  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4),
-  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4),
-  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 3),
-  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 3),
-  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3),
-  [75] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3),
+  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctype, 4),
+  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctype, 4),
+  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 3),
+  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 3),
+  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [75] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
   [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 3),
   [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 3),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 4),
-  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 4),
-  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctype, 4),
-  [87] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctype, 4),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 3),
-  [91] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 3),
-  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
-  [95] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
-  [97] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_component, 3),
-  [99] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_component, 3),
-  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
-  [103] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
-  [105] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 2),
-  [107] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 2),
-  [109] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 4),
-  [111] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 4),
-  [113] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 4),
-  [115] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 4),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 3),
-  [119] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 3),
-  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 3),
-  [123] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 3),
-  [125] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2),
-  [127] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(34),
-  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(33),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3, .production_id = 1),
+  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3, .production_id = 1),
+  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_component, 3),
+  [87] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_component, 3),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
+  [91] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 3),
+  [95] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 3),
+  [97] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 2),
+  [99] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 2),
+  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 4),
+  [103] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 4),
+  [105] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3),
+  [107] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_tag, 3),
+  [109] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 4),
+  [111] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 4),
+  [113] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 4),
+  [115] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 4),
+  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 3),
+  [119] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 3),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 3),
+  [123] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 3),
+  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2),
+  [135] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(36),
+  [138] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(33),
+  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
   [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 1),
   [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [163] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [167] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [169] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3),
-  [171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2),
-  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3),
-  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3),
+  [163] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(42),
+  [166] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2),
+  [168] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(48),
+  [171] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [173] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
   [177] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [179] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
-  [181] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2), SHIFT_REPEAT(43),
-  [184] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2),
-  [186] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [188] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 1),
-  [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [196] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_value, 1),
-  [208] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [212] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [220] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_value, 3, .production_id = 2),
-  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [179] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [185] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3),
+  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2),
+  [189] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3, .production_id = 1),
+  [193] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 2),
+  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [201] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [203] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 2),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 2),
+  [207] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 3),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 3),
+  [211] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2), SHIFT_REPEAT(55),
+  [214] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2),
+  [216] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 1),
+  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 1),
+  [220] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
+  [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [228] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [234] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 1),
+  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [240] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [242] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [244] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [246] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -50,3 +50,20 @@ Nested Empty Tuples
         (attribute_name)
         (expression
           (expression_value))))))
+
+================================================================================
+Interpolation
+================================================================================
+
+<div id={ "##{@id}" } />
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (tag
+    (self_closing_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (expression
+          (expression_value))))))


### PR DESCRIPTION
I found some odd behavior parsing a case like this:

```html
<div phx-value-target={ "##{@id}" }></div>
```

where the expression_value node has a hard time dealing with the brackets `{..}`. Here's the parse result:

```
(fragment [0, 0] - [1, 0]
  (tag [0, 0] - [0, 42]
    (start_tag [0, 0] - [0, 36]
      (tag_name [0, 1] - [0, 4])
      (attribute [0, 5] - [0, 35]
        (attribute_name [0, 5] - [0, 21])
        (expression [0, 22] - [0, 35]
          (ERROR [0, 23] - [0, 27]
            (expression_value [0, 23] - [0, 27]))
          (expression_value [0, 27] - [0, 32])
          (ERROR [0, 32] - [0, 33]))))
    (end_tag [0, 36] - [0, 42]
      (tag_name [0, 38] - [0, 41]))))
```

I shuffled around the grammar rules for expression_value a bit so we use a hidden `$._expression_value` which can repeat to capture everything in the expression's brackets. Then we alias those repeating hidden nodes all together as one expression_value node. The tree for that example case ends up looking like so

```
(fragment [0, 0] - [1, 0]
  (tag [0, 0] - [0, 42]
    (start_tag [0, 0] - [0, 36]
      (tag_name [0, 1] - [0, 4])
      (attribute [0, 5] - [0, 35]
        (attribute_name [0, 5] - [0, 21])
        (expression [0, 22] - [0, 35]
          (expression_value [0, 23] - [0, 34]))))
    (end_tag [0, 36] - [0, 42]
      (tag_name [0, 38] - [0, 41]))))
```