### PR TITLE
add highlight and injection queries and partial_expression_value node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -150,7 +150,7 @@ module.exports = grammar({
       choice('<%', '<%=', '<%%', '<%%='),
       prec.left(
         seq(
-          alias(repeat1(/[^%]+|%/), $.expression_value),
+          choice($.partial_expression_value, $.expression_value),
           '%>',
         )
       )
@@ -182,11 +182,22 @@ module.exports = grammar({
       '<%#',
       prec.left(
         seq(
-          repeat1(/[^%]+|%/),
+          repeat1($._code),
           '%>'
         )
       )
     ),
+
+    expression_value: $ => repeat1($._code),
+
+    partial_expression_value: $ => seq(
+      choice(
+        seq(/end[\)\]\}]*/, repeat($._code)),
+        seq(repeat($._code), choice('do', '->'), optional(seq('#', repeat($._code)))),
+      ),
+    ),
+
+    _code: $ => /[^%\s]+|[%\s]/,
 
     tag_name: $ => /[a-z]+[^\-<>{}!"'/=\s]*/,
 

--- a/grammar.js
+++ b/grammar.js
@@ -197,13 +197,20 @@ module.exports = grammar({
       ),
     ),
 
+    component_name: $ => choice(
+      seq(optional($.module), seq(".", $.function)),
+      $.module
+    ),
+
+    module: $ => /([A-Z][^\-<>{}!"'/=\s\.]*)(\.[A-Z][^\-<>{}!"'/=\s\.]*)*/,
+
+    function: $ => /[a-z][^\-<>{}!"'/=\s\.]*/,
+
     _code: $ => /[^%\s]+|[%\s]/,
 
     tag_name: $ => /[a-z]+[^\-<>{}!"'/=\s]*/,
 
-    component_name: $ => /[.A-Z]+[^\-<>{}!"'/=\s]*/,
-
-    attribute_name: $ => /[^<>{}"'/=\s]+/,
+    attribute_name: $ => token(prec(-1, /[^<>{}"'/=\s]+/)),
 
     text: $ => /[^<>{}\s]([^<>{}]*[^<>{}\s])?/,
 }})

--- a/package.json
+++ b/package.json
@@ -13,5 +13,12 @@
   "devDependencies": {
     "tree-sitter-cli": "^0.20.0",
     "nan": "^2.15.0"
-  }
+  },
+  "tree-sitter": [
+    {
+      "file-types": [
+        "heex"
+      ]
+    }
+  ]
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -2,7 +2,10 @@
 
 ; HEEx attributes are highlighted as HTML attributes
 (attribute_name) @attribute
-(quoted_attribute_value) @string
+[
+  (attribute_value)
+  (quoted_attribute_value)
+] @string
 
 ; HEEx tags are highlighted as HTML
 (tag_name) @tag
@@ -31,3 +34,5 @@
 "=" @operator
 
 (comment) @comment
+
+(ERROR) @error

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -10,8 +10,13 @@
 ; HEEx tags are highlighted as HTML
 (tag_name) @tag
 
-; HEEx components are highlighted as types (Elixir modules)
-(component_name) @module
+; HEEx components are highlighted as Elixir modules and functions
+(component_name
+  [
+    (module) @module
+    (function) @function
+    "." @punctuation.delimiter
+  ])
 
 [
   "/>"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -26,12 +26,9 @@
   ">"
 ] @punctuation.bracket
 
+(directive ["<%" "<%%=" "<%=" "%>"] @keyword)
+
 [
-  "<%"
-  "<%#"
-  "<%%="
-  "<%="
-  "%>"
   "{"
   "}"
 ] @keyword

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,33 @@
+(doctype) @constant
+
+; HEEx attributes are highlighted as HTML attributes
+(attribute_name) @attribute
+(quoted_attribute_value) @string
+
+; HEEx tags are highlighted as HTML
+(tag_name) @tag
+
+; HEEx components are highlighted as types (Elixir modules)
+(component_name) @module
+
+[
+  "/>"
+  "<!"
+  "<"
+  "</"
+  ">"
+] @punctuation.bracket
+
+[
+  "<%"
+  "<%#"
+  "<%%="
+  "<%="
+  "%>"
+  "{"
+  "}"
+] @keyword
+
+"=" @operator
+
+(comment) @comment

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,5 +1,8 @@
 (doctype) @constant
 
+((attribute_name) @keyword
+ (#match? @keyword "^phx-"))
+
 ; HEEx attributes are highlighted as HTML attributes
 (attribute_name) @attribute
 [

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,20 @@
+; directives are standalone tags like '<%= @x %>'
+;
+; partial_expression_values are elixir code that is part of an expression that
+; spans multiple directive nodes, so they must be combined. For example:
+;     <%= if true do %>
+;       <p>hello, tree-sitter!</p>
+;     <% end %>
+((directive (partial_expression_value) @injection.content)
+ (#set! injection.language "elixir")
+ (#set! injection.include-children)
+ (#set! injection.combined))
+
+; Regular expression_values do not need to be combined
+((directive (expression_value) @injection.content)
+ (#set! injection.language "elixir"))
+
+; expressions live within HTML tags, and do not need to be combined
+;     <link href={ Routes.static_path(..) } />
+((expression (expression_value) @injection.content)
+ (#set! injection.language "elixir"))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -493,16 +493,17 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^%]+|%"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "partial_expression_value"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression_value"
                   }
-                },
-                "named": true,
-                "value": "expression_value"
+                ]
               },
               {
                 "type": "STRING",
@@ -604,8 +605,8 @@
               {
                 "type": "REPEAT1",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^%]+|%"
+                  "type": "SYMBOL",
+                  "name": "_code"
                 }
               },
               {
@@ -616,6 +617,92 @@
           }
         }
       ]
+    },
+    "expression_value": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_code"
+      }
+    },
+    "partial_expression_value": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "end[\\)\\]\\}]*"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_code"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_code"
+                  }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "do"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "->"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "#"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_code"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "_code": {
+      "type": "PATTERN",
+      "value": "[^%\\s]+|[%\\s]"
     },
     "tag_name": {
       "type": "PATTERN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -700,6 +700,53 @@
         }
       ]
     },
+    "component_name": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "module"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "."
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "function"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "module"
+        }
+      ]
+    },
+    "module": {
+      "type": "PATTERN",
+      "value": "([A-Z][^\\-<>{}!\"'/=\\s\\.]*)(\\.[A-Z][^\\-<>{}!\"'/=\\s\\.]*)*"
+    },
+    "function": {
+      "type": "PATTERN",
+      "value": "[a-z][^\\-<>{}!\"'/=\\s\\.]*"
+    },
     "_code": {
       "type": "PATTERN",
       "value": "[^%\\s]+|[%\\s]"
@@ -708,13 +755,16 @@
       "type": "PATTERN",
       "value": "[a-z]+[^\\-<>{}!\"'/=\\s]*"
     },
-    "component_name": {
-      "type": "PATTERN",
-      "value": "[.A-Z]+[^\\-<>{}!\"'/=\\s]*"
-    },
     "attribute_name": {
-      "type": "PATTERN",
-      "value": "[^<>{}\"'/=\\s]+"
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "PATTERN",
+          "value": "[^<>{}\"'/=\\s]+"
+        }
+      }
     },
     "text": {
       "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -79,6 +79,25 @@
     }
   },
   {
+    "type": "component_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function",
+          "named": true
+        },
+        {
+          "type": "module",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "directive",
     "named": true,
     "fields": {},
@@ -375,6 +394,10 @@
     "named": false
   },
   {
+    "type": ".",
+    "named": false
+  },
+  {
     "type": "/>",
     "named": false
   },
@@ -439,16 +462,20 @@
     "named": true
   },
   {
-    "type": "component_name",
-    "named": true
-  },
-  {
     "type": "do",
     "named": false
   },
   {
+    "type": "function",
+    "named": true
+  },
+  {
     "type": "html",
     "named": false
+  },
+  {
+    "type": "module",
+    "named": true
   },
   {
     "type": "tag_name",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -89,6 +89,10 @@
         {
           "type": "expression_value",
           "named": true
+        },
+        {
+          "type": "partial_expression_value",
+          "named": true
         }
       ]
     }
@@ -182,6 +186,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "partial_expression_value",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "quoted_attribute_value",
@@ -342,6 +351,10 @@
     "named": false
   },
   {
+    "type": "#",
+    "named": false
+  },
+  {
     "type": "%>",
     "named": false
   },
@@ -355,6 +368,10 @@
   },
   {
     "type": "-->",
+    "named": false
+  },
+  {
+    "type": "->",
     "named": false
   },
   {
@@ -424,6 +441,10 @@
   {
     "type": "component_name",
     "named": true
+  },
+  {
+    "type": "do",
+    "named": false
   },
   {
     "type": "html",

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,11 +6,11 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 79
+#define STATE_COUNT 88
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 58
-#define ALIAS_COUNT 1
-#define TOKEN_COUNT 33
+#define SYMBOL_COUNT 64
+#define ALIAS_COUNT 0
+#define TOKEN_COUNT 37
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
@@ -37,44 +37,49 @@ enum {
   anon_sym_LT_PERCENT_EQ = 18,
   anon_sym_LT_PERCENT_PERCENT = 19,
   anon_sym_LT_PERCENT_PERCENT_EQ = 20,
-  aux_sym_directive_token1 = 21,
-  anon_sym_PERCENT_GT = 22,
-  anon_sym_LT_BANG_DASH_DASH = 23,
-  aux_sym__html_comment_token1 = 24,
-  anon_sym_DASH_DASH_GT = 25,
-  anon_sym_LT_PERCENT_BANG_DASH_DASH = 26,
-  anon_sym_DASH_DASH_PERCENT_GT = 27,
-  anon_sym_LT_PERCENT_POUND = 28,
-  sym_tag_name = 29,
-  sym_component_name = 30,
-  sym_attribute_name = 31,
-  sym_text = 32,
-  sym_fragment = 33,
-  sym__node = 34,
-  sym_doctype = 35,
-  sym_tag = 36,
-  sym_component = 37,
-  sym_start_tag = 38,
-  sym_end_tag = 39,
-  sym_self_closing_tag = 40,
-  sym_start_component = 41,
-  sym_end_component = 42,
-  sym_self_closing_component = 43,
-  sym_expression = 44,
-  sym__expression_value = 45,
-  sym_attribute = 46,
-  sym_quoted_attribute_value = 47,
-  sym_directive = 48,
-  sym_comment = 49,
-  sym__html_comment = 50,
-  sym__bang_comment = 51,
-  sym__hash_comment = 52,
-  aux_sym_fragment_repeat1 = 53,
-  aux_sym_start_tag_repeat1 = 54,
-  aux_sym_expression_repeat1 = 55,
-  aux_sym_directive_repeat1 = 56,
-  aux_sym__html_comment_repeat1 = 57,
-  alias_sym_expression_value = 58,
+  anon_sym_PERCENT_GT = 21,
+  anon_sym_LT_BANG_DASH_DASH = 22,
+  aux_sym__html_comment_token1 = 23,
+  anon_sym_DASH_DASH_GT = 24,
+  anon_sym_LT_PERCENT_BANG_DASH_DASH = 25,
+  anon_sym_DASH_DASH_PERCENT_GT = 26,
+  anon_sym_LT_PERCENT_POUND = 27,
+  aux_sym_partial_expression_value_token1 = 28,
+  anon_sym_do = 29,
+  anon_sym_DASH_GT = 30,
+  anon_sym_POUND = 31,
+  sym__code = 32,
+  sym_tag_name = 33,
+  sym_component_name = 34,
+  sym_attribute_name = 35,
+  sym_text = 36,
+  sym_fragment = 37,
+  sym__node = 38,
+  sym_doctype = 39,
+  sym_tag = 40,
+  sym_component = 41,
+  sym_start_tag = 42,
+  sym_end_tag = 43,
+  sym_self_closing_tag = 44,
+  sym_start_component = 45,
+  sym_end_component = 46,
+  sym_self_closing_component = 47,
+  sym_expression = 48,
+  sym__expression_value = 49,
+  sym_attribute = 50,
+  sym_quoted_attribute_value = 51,
+  sym_directive = 52,
+  sym_comment = 53,
+  sym__html_comment = 54,
+  sym__bang_comment = 55,
+  sym__hash_comment = 56,
+  sym_expression_value = 57,
+  sym_partial_expression_value = 58,
+  aux_sym_fragment_repeat1 = 59,
+  aux_sym_start_tag_repeat1 = 60,
+  aux_sym_expression_repeat1 = 61,
+  aux_sym__html_comment_repeat1 = 62,
+  aux_sym__hash_comment_repeat1 = 63,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -99,7 +104,6 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LT_PERCENT_EQ] = "<%=",
   [anon_sym_LT_PERCENT_PERCENT] = "<%%",
   [anon_sym_LT_PERCENT_PERCENT_EQ] = "<%%=",
-  [aux_sym_directive_token1] = "directive_token1",
   [anon_sym_PERCENT_GT] = "%>",
   [anon_sym_LT_BANG_DASH_DASH] = "<!--",
   [aux_sym__html_comment_token1] = "_html_comment_token1",
@@ -107,6 +111,11 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LT_PERCENT_BANG_DASH_DASH] = "<%!--",
   [anon_sym_DASH_DASH_PERCENT_GT] = "--%>",
   [anon_sym_LT_PERCENT_POUND] = "<%#",
+  [aux_sym_partial_expression_value_token1] = "partial_expression_value_token1",
+  [anon_sym_do] = "do",
+  [anon_sym_DASH_GT] = "->",
+  [anon_sym_POUND] = "#",
+  [sym__code] = "_code",
   [sym_tag_name] = "tag_name",
   [sym_component_name] = "component_name",
   [sym_attribute_name] = "attribute_name",
@@ -131,12 +140,13 @@ static const char * const ts_symbol_names[] = {
   [sym__html_comment] = "_html_comment",
   [sym__bang_comment] = "_bang_comment",
   [sym__hash_comment] = "_hash_comment",
+  [sym_expression_value] = "expression_value",
+  [sym_partial_expression_value] = "partial_expression_value",
   [aux_sym_fragment_repeat1] = "fragment_repeat1",
   [aux_sym_start_tag_repeat1] = "start_tag_repeat1",
   [aux_sym_expression_repeat1] = "expression_repeat1",
-  [aux_sym_directive_repeat1] = "directive_repeat1",
   [aux_sym__html_comment_repeat1] = "_html_comment_repeat1",
-  [alias_sym_expression_value] = "expression_value",
+  [aux_sym__hash_comment_repeat1] = "_hash_comment_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -161,7 +171,6 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LT_PERCENT_EQ] = anon_sym_LT_PERCENT_EQ,
   [anon_sym_LT_PERCENT_PERCENT] = anon_sym_LT_PERCENT_PERCENT,
   [anon_sym_LT_PERCENT_PERCENT_EQ] = anon_sym_LT_PERCENT_PERCENT_EQ,
-  [aux_sym_directive_token1] = aux_sym_directive_token1,
   [anon_sym_PERCENT_GT] = anon_sym_PERCENT_GT,
   [anon_sym_LT_BANG_DASH_DASH] = anon_sym_LT_BANG_DASH_DASH,
   [aux_sym__html_comment_token1] = aux_sym__html_comment_token1,
@@ -169,6 +178,11 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LT_PERCENT_BANG_DASH_DASH] = anon_sym_LT_PERCENT_BANG_DASH_DASH,
   [anon_sym_DASH_DASH_PERCENT_GT] = anon_sym_DASH_DASH_PERCENT_GT,
   [anon_sym_LT_PERCENT_POUND] = anon_sym_LT_PERCENT_POUND,
+  [aux_sym_partial_expression_value_token1] = aux_sym_partial_expression_value_token1,
+  [anon_sym_do] = anon_sym_do,
+  [anon_sym_DASH_GT] = anon_sym_DASH_GT,
+  [anon_sym_POUND] = anon_sym_POUND,
+  [sym__code] = sym__code,
   [sym_tag_name] = sym_tag_name,
   [sym_component_name] = sym_component_name,
   [sym_attribute_name] = sym_attribute_name,
@@ -193,12 +207,13 @@ static const TSSymbol ts_symbol_map[] = {
   [sym__html_comment] = sym__html_comment,
   [sym__bang_comment] = sym__bang_comment,
   [sym__hash_comment] = sym__hash_comment,
+  [sym_expression_value] = sym_expression_value,
+  [sym_partial_expression_value] = sym_partial_expression_value,
   [aux_sym_fragment_repeat1] = aux_sym_fragment_repeat1,
   [aux_sym_start_tag_repeat1] = aux_sym_start_tag_repeat1,
   [aux_sym_expression_repeat1] = aux_sym_expression_repeat1,
-  [aux_sym_directive_repeat1] = aux_sym_directive_repeat1,
   [aux_sym__html_comment_repeat1] = aux_sym__html_comment_repeat1,
-  [alias_sym_expression_value] = alias_sym_expression_value,
+  [aux_sym__hash_comment_repeat1] = aux_sym__hash_comment_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -286,10 +301,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_directive_token1] = {
-    .visible = false,
-    .named = false,
-  },
   [anon_sym_PERCENT_GT] = {
     .visible = true,
     .named = false,
@@ -317,6 +328,26 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   [anon_sym_LT_PERCENT_POUND] = {
     .visible = true,
     .named = false,
+  },
+  [aux_sym_partial_expression_value_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_do] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_POUND] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym__code] = {
+    .visible = false,
+    .named = true,
   },
   [sym_tag_name] = {
     .visible = true,
@@ -414,6 +445,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = true,
   },
+  [sym_expression_value] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_partial_expression_value] = {
+    .visible = true,
+    .named = true,
+  },
   [aux_sym_fragment_repeat1] = {
     .visible = false,
     .named = false,
@@ -426,34 +465,27 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_directive_repeat1] = {
-    .visible = false,
-    .named = false,
-  },
   [aux_sym__html_comment_repeat1] = {
     .visible = false,
     .named = false,
   },
-  [alias_sym_expression_value] = {
-    .visible = true,
-    .named = true,
+  [aux_sym__hash_comment_repeat1] = {
+    .visible = false,
+    .named = false,
   },
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
   [1] = {
-    [1] = alias_sym_expression_value,
+    [1] = sym_expression_value,
   },
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
   aux_sym_expression_repeat1, 2,
     aux_sym_expression_repeat1,
-    alias_sym_expression_value,
-  aux_sym_directive_repeat1, 2,
-    aux_sym_directive_repeat1,
-    alias_sym_expression_value,
+    sym_expression_value,
   0,
 };
 
@@ -522,470 +554,585 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(34);
-      if (lookahead == '"') ADVANCE(52);
-      if (lookahead == '%') ADVANCE(16);
-      if (lookahead == '\'') ADVANCE(49);
-      if (lookahead == '-') ADVANCE(8);
-      if (lookahead == '/') ADVANCE(17);
-      if (lookahead == '<') ADVANCE(40);
-      if (lookahead == '=') ADVANCE(47);
-      if (lookahead == '>') ADVANCE(39);
-      if (lookahead == 'D') ADVANCE(22);
-      if (lookahead == 'h') ADVANCE(79);
-      if (lookahead == '{') ADVANCE(43);
-      if (lookahead == '}') ADVANCE(44);
+      if (eof) ADVANCE(38);
+      if (lookahead == '"') ADVANCE(55);
+      if (lookahead == '#') ADVANCE(81);
+      if (lookahead == '%') ADVANCE(18);
+      if (lookahead == '\'') ADVANCE(52);
+      if (lookahead == '-') ADVANCE(10);
+      if (lookahead == '/') ADVANCE(19);
+      if (lookahead == '<') ADVANCE(43);
+      if (lookahead == '=') ADVANCE(50);
+      if (lookahead == '>') ADVANCE(42);
+      if (lookahead == 'D') ADVANCE(24);
+      if (lookahead == 'd') ADVANCE(32);
+      if (lookahead == 'e') ADVANCE(31);
+      if (lookahead == 'h') ADVANCE(33);
+      if (lookahead == '{') ADVANCE(46);
+      if (lookahead == '}') ADVANCE(47);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(52);
-      if (lookahead == '\'') ADVANCE(49);
-      if (lookahead == '{') ADVANCE(43);
+      if (lookahead == '"') ADVANCE(55);
+      if (lookahead == '\'') ADVANCE(52);
+      if (lookahead == '{') ADVANCE(46);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(1)
       if (lookahead != 0 &&
           (lookahead < '<' || '>' < lookahead) &&
-          lookahead != '}') ADVANCE(48);
+          lookahead != '}') ADVANCE(51);
       END_STATE();
     case 2:
-      if (lookahead == '"') ADVANCE(52);
+      if (lookahead == '"') ADVANCE(55);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(56);
+      if (lookahead != 0) ADVANCE(57);
+      END_STATE();
+    case 3:
+      if (lookahead == '%') ADVANCE(82);
+      if (lookahead == '-') ADVANCE(88);
+      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == 'e') ADVANCE(90);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(83);
+      if (lookahead != 0) ADVANCE(92);
+      END_STATE();
+    case 4:
+      if (lookahead == '%') ADVANCE(82);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(84);
+      if (lookahead != 0) ADVANCE(92);
+      END_STATE();
+    case 5:
+      if (lookahead == '%') ADVANCE(87);
+      if (lookahead == '-') ADVANCE(88);
+      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(85);
+      if (lookahead != 0) ADVANCE(92);
+      END_STATE();
+    case 6:
+      if (lookahead == '%') ADVANCE(87);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(86);
+      if (lookahead != 0) ADVANCE(92);
+      END_STATE();
+    case 7:
+      if (lookahead == '%') ADVANCE(21);
+      END_STATE();
+    case 8:
+      if (lookahead == '%') ADVANCE(21);
+      if (lookahead == '>') ADVANCE(71);
+      END_STATE();
+    case 9:
+      if (lookahead == '\'') ADVANCE(52);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(53);
       if (lookahead != 0) ADVANCE(54);
       END_STATE();
-    case 3:
-      if (lookahead == '%') ADVANCE(62);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(60);
-      if (lookahead != 0) ADVANCE(63);
-      END_STATE();
-    case 4:
-      if (lookahead == '%') ADVANCE(59);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(61);
-      if (lookahead != 0) ADVANCE(63);
-      END_STATE();
-    case 5:
-      if (lookahead == '%') ADVANCE(19);
-      END_STATE();
-    case 6:
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '>') ADVANCE(73);
-      END_STATE();
-    case 7:
-      if (lookahead == '\'') ADVANCE(49);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(50);
-      if (lookahead != 0) ADVANCE(51);
-      END_STATE();
-    case 8:
-      if (lookahead == '-') ADVANCE(6);
-      END_STATE();
-    case 9:
-      if (lookahead == '-') ADVANCE(65);
-      END_STATE();
     case 10:
-      if (lookahead == '-') ADVANCE(74);
+      if (lookahead == '-') ADVANCE(8);
+      if (lookahead == '>') ADVANCE(79);
       END_STATE();
     case 11:
-      if (lookahead == '-') ADVANCE(71);
+      if (lookahead == '-') ADVANCE(63);
+      END_STATE();
+    case 12:
+      if (lookahead == '-') ADVANCE(72);
+      END_STATE();
+    case 13:
+      if (lookahead == '-') ADVANCE(69);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(65);
+      if (lookahead != 0) ADVANCE(70);
+      END_STATE();
+    case 14:
+      if (lookahead == '-') ADVANCE(64);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(67);
-      if (lookahead != 0) ADVANCE(72);
+      if (lookahead != 0) ADVANCE(70);
       END_STATE();
-    case 12:
+    case 15:
       if (lookahead == '-') ADVANCE(66);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(69);
-      if (lookahead != 0) ADVANCE(72);
+          lookahead == ' ') ADVANCE(68);
+      if (lookahead != 0) ADVANCE(70);
       END_STATE();
-    case 13:
-      if (lookahead == '-') ADVANCE(68);
+    case 16:
+      if (lookahead == '-') ADVANCE(12);
+      END_STATE();
+    case 17:
+      if (lookahead == '/') ADVANCE(19);
+      if (lookahead == '=') ADVANCE(50);
+      if (lookahead == '>') ADVANCE(42);
+      if (lookahead == '{') ADVANCE(46);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(70);
-      if (lookahead != 0) ADVANCE(72);
-      END_STATE();
-    case 14:
-      if (lookahead == '-') ADVANCE(10);
-      END_STATE();
-    case 15:
-      if (lookahead == '/') ADVANCE(17);
-      if (lookahead == '=') ADVANCE(47);
-      if (lookahead == '>') ADVANCE(39);
-      if (lookahead == '{') ADVANCE(43);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(15)
+          lookahead == ' ') SKIP(17)
       if (lookahead != 0 &&
           lookahead != '"' &&
           lookahead != '\'' &&
           lookahead != '<' &&
-          lookahead != '}') ADVANCE(84);
-      END_STATE();
-    case 16:
-      if (lookahead == '>') ADVANCE(64);
-      END_STATE();
-    case 17:
-      if (lookahead == '>') ADVANCE(42);
+          lookahead != '}') ADVANCE(97);
       END_STATE();
     case 18:
-      if (lookahead == '>') ADVANCE(73);
+      if (lookahead == '>') ADVANCE(62);
       END_STATE();
     case 19:
-      if (lookahead == '>') ADVANCE(75);
+      if (lookahead == '>') ADVANCE(45);
       END_STATE();
     case 20:
-      if (lookahead == 'C') ADVANCE(24);
+      if (lookahead == '>') ADVANCE(71);
       END_STATE();
     case 21:
-      if (lookahead == 'E') ADVANCE(36);
+      if (lookahead == '>') ADVANCE(73);
       END_STATE();
     case 22:
-      if (lookahead == 'O') ADVANCE(20);
+      if (lookahead == 'C') ADVANCE(26);
       END_STATE();
     case 23:
-      if (lookahead == 'P') ADVANCE(21);
+      if (lookahead == 'E') ADVANCE(40);
       END_STATE();
     case 24:
-      if (lookahead == 'T') ADVANCE(25);
+      if (lookahead == 'O') ADVANCE(22);
       END_STATE();
     case 25:
-      if (lookahead == 'Y') ADVANCE(23);
+      if (lookahead == 'P') ADVANCE(23);
       END_STATE();
     case 26:
-      if (lookahead == 'h') ADVANCE(29);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(26)
+      if (lookahead == 'T') ADVANCE(27);
       END_STATE();
     case 27:
-      if (lookahead == 'l') ADVANCE(37);
+      if (lookahead == 'Y') ADVANCE(25);
       END_STATE();
     case 28:
-      if (lookahead == 'm') ADVANCE(27);
+      if (lookahead == 'd') ADVANCE(75);
       END_STATE();
     case 29:
-      if (lookahead == 't') ADVANCE(28);
+      if (lookahead == 'l') ADVANCE(41);
       END_STATE();
     case 30:
-      if (lookahead == '{') ADVANCE(43);
-      if (lookahead == '}') ADVANCE(44);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(45);
-      if (lookahead != 0) ADVANCE(46);
+      if (lookahead == 'm') ADVANCE(29);
       END_STATE();
     case 31:
+      if (lookahead == 'n') ADVANCE(28);
+      END_STATE();
+    case 32:
+      if (lookahead == 'o') ADVANCE(77);
+      END_STATE();
+    case 33:
+      if (lookahead == 't') ADVANCE(30);
+      END_STATE();
+    case 34:
+      if (lookahead == '{') ADVANCE(46);
+      if (lookahead == '}') ADVANCE(47);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(31);
+          lookahead == ' ') ADVANCE(48);
+      if (lookahead != 0) ADVANCE(49);
+      END_STATE();
+    case 35:
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(35);
       if (lookahead != 0 &&
           lookahead != '<' &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(85);
+          lookahead != '}') ADVANCE(98);
       END_STATE();
-    case 32:
+    case 36:
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(32)
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+          lookahead == ' ') SKIP(36)
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(82);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(95);
       END_STATE();
-    case 33:
-      if (eof) ADVANCE(34);
-      if (lookahead == '<') ADVANCE(40);
+    case 37:
+      if (eof) ADVANCE(38);
+      if (lookahead == '<') ADVANCE(43);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(33)
+          lookahead == ' ') SKIP(37)
       if (lookahead != 0 &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(85);
-      END_STATE();
-    case 34:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 35:
-      ACCEPT_TOKEN(anon_sym_LT_BANG);
-      if (lookahead == '-') ADVANCE(9);
-      END_STATE();
-    case 36:
-      ACCEPT_TOKEN(anon_sym_DOCTYPE);
-      END_STATE();
-    case 37:
-      ACCEPT_TOKEN(anon_sym_html);
+          lookahead != '}') ADVANCE(98);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(anon_sym_html);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(81);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 39:
-      ACCEPT_TOKEN(anon_sym_GT);
+      ACCEPT_TOKEN(anon_sym_LT_BANG);
+      if (lookahead == '-') ADVANCE(11);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '!') ADVANCE(35);
-      if (lookahead == '%') ADVANCE(55);
-      if (lookahead == '/') ADVANCE(41);
+      ACCEPT_TOKEN(anon_sym_DOCTYPE);
       END_STATE();
     case 41:
-      ACCEPT_TOKEN(anon_sym_LT_SLASH);
+      ACCEPT_TOKEN(anon_sym_html);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(anon_sym_SLASH_GT);
+      ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
     case 43:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '!') ADVANCE(39);
+      if (lookahead == '%') ADVANCE(58);
+      if (lookahead == '/') ADVANCE(44);
       END_STATE();
     case 44:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(anon_sym_LT_SLASH);
       END_STATE();
     case 45:
-      ACCEPT_TOKEN(aux_sym__expression_value_token1);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(45);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(46);
+      ACCEPT_TOKEN(anon_sym_SLASH_GT);
       END_STATE();
     case 46:
-      ACCEPT_TOKEN(aux_sym__expression_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(46);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 47:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(sym_attribute_value);
-      if (!sym_attribute_value_character_set_1(lookahead)) ADVANCE(48);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
-      END_STATE();
-    case 50:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
+      ACCEPT_TOKEN(aux_sym__expression_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(50);
+          lookahead == ' ') ADVANCE(48);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(51);
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(49);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(aux_sym__expression_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(49);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(51);
+      ACCEPT_TOKEN(sym_attribute_value);
+      if (!sym_attribute_value_character_set_1(lookahead)) ADVANCE(51);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
+      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(53);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(54);
+          lookahead != '\'') ADVANCE(54);
       END_STATE();
     case 54:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
+      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(54);
+          lookahead != '\'') ADVANCE(54);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
-      if (lookahead == '!') ADVANCE(14);
-      if (lookahead == '#') ADVANCE(76);
-      if (lookahead == '%') ADVANCE(57);
-      if (lookahead == '=') ADVANCE(56);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
+      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(56);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(57);
       END_STATE();
     case 57:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
-      if (lookahead == '=') ADVANCE(58);
+      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(57);
       END_STATE();
     case 58:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT_EQ);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
+      if (lookahead == '!') ADVANCE(16);
+      if (lookahead == '#') ADVANCE(74);
+      if (lookahead == '%') ADVANCE(60);
+      if (lookahead == '=') ADVANCE(59);
       END_STATE();
     case 59:
-      ACCEPT_TOKEN(aux_sym_directive_token1);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
       END_STATE();
     case 60:
-      ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead == '%') ADVANCE(62);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(60);
-      if (lookahead != 0) ADVANCE(63);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
+      if (lookahead == '=') ADVANCE(61);
       END_STATE();
     case 61:
-      ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead == '%') ADVANCE(59);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT_EQ);
+      END_STATE();
+    case 62:
+      ACCEPT_TOKEN(anon_sym_PERCENT_GT);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(anon_sym_LT_BANG_DASH_DASH);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(aux_sym__html_comment_token1);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(aux_sym__html_comment_token1);
+      if (lookahead == '-') ADVANCE(69);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(61);
-      if (lookahead != 0) ADVANCE(63);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead == '>') ADVANCE(64);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(aux_sym_directive_token1);
-      if (lookahead != 0 &&
-          lookahead != '%') ADVANCE(63);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(anon_sym_PERCENT_GT);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(anon_sym_LT_BANG_DASH_DASH);
+          lookahead == ' ') ADVANCE(65);
+      if (lookahead != 0) ADVANCE(70);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
+      if (lookahead == '-') ADVANCE(7);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(71);
+      if (lookahead == '-') ADVANCE(64);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(67);
-      if (lookahead != 0) ADVANCE(72);
+      if (lookahead != 0) ADVANCE(70);
       END_STATE();
     case 68:
-      ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(5);
-      END_STATE();
-    case 69:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
       if (lookahead == '-') ADVANCE(66);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(69);
-      if (lookahead != 0) ADVANCE(72);
+          lookahead == ' ') ADVANCE(68);
+      if (lookahead != 0) ADVANCE(70);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(aux_sym__html_comment_token1);
+      if (lookahead == '-') ADVANCE(20);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(68);
+      if (lookahead != 0 &&
+          lookahead != '-') ADVANCE(70);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(anon_sym_DASH_DASH_GT);
+      END_STATE();
+    case 72:
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_BANG_DASH_DASH);
+      END_STATE();
+    case 73:
+      ACCEPT_TOKEN(anon_sym_DASH_DASH_PERCENT_GT);
+      END_STATE();
+    case 74:
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
+      END_STATE();
+    case 75:
+      ACCEPT_TOKEN(aux_sym_partial_expression_value_token1);
+      if (lookahead == ')' ||
+          lookahead == ']' ||
+          lookahead == '}') ADVANCE(75);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(aux_sym_partial_expression_value_token1);
+      if (lookahead == ')' ||
+          lookahead == ']' ||
+          lookahead == '}') ADVANCE(76);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(anon_sym_do);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(anon_sym_do);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 81:
+      ACCEPT_TOKEN(anon_sym_POUND);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(sym__code);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '%') ADVANCE(82);
+      if (lookahead == '-') ADVANCE(88);
+      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == 'e') ADVANCE(90);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(70);
-      if (lookahead != 0) ADVANCE(72);
-      END_STATE();
-    case 71:
-      ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(18);
-      END_STATE();
-    case 72:
-      ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead != 0 &&
-          lookahead != '-') ADVANCE(72);
-      END_STATE();
-    case 73:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH_GT);
-      END_STATE();
-    case 74:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_BANG_DASH_DASH);
-      END_STATE();
-    case 75:
-      ACCEPT_TOKEN(anon_sym_DASH_DASH_PERCENT_GT);
-      END_STATE();
-    case 76:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
-      END_STATE();
-    case 77:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(38);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(81);
-      END_STATE();
-    case 78:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(77);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(81);
-      END_STATE();
-    case 79:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(78);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(81);
-      END_STATE();
-    case 80:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(81);
-      END_STATE();
-    case 81:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(81);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(sym_component_name);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(82);
-      if (!sym_component_name_character_set_1(lookahead)) ADVANCE(83);
-      END_STATE();
-    case 83:
-      ACCEPT_TOKEN(sym_component_name);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(83);
+          lookahead == ' ') ADVANCE(83);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 84:
-      ACCEPT_TOKEN(sym_attribute_name);
-      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(84);
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '%') ADVANCE(82);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(84);
+      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 85:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '%') ADVANCE(87);
+      if (lookahead == '-') ADVANCE(88);
+      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(85);
+      if (lookahead != 0) ADVANCE(92);
+      END_STATE();
+    case 86:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '%') ADVANCE(87);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(86);
+      if (lookahead != 0) ADVANCE(92);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '>') ADVANCE(62);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '>') ADVANCE(80);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == 'd') ADVANCE(76);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == 'n') ADVANCE(89);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == 'o') ADVANCE(78);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead != 0 &&
+          lookahead != '\t' &&
+          lookahead != '\n' &&
+          lookahead != '\r' &&
+          lookahead != ' ' &&
+          lookahead != '%') ADVANCE(92);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(94);
+      END_STATE();
+    case 94:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(94);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(sym_component_name);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(95);
+      if (!sym_component_name_character_set_1(lookahead)) ADVANCE(96);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(sym_component_name);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(96);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(97);
+      END_STATE();
+    case 98:
       ACCEPT_TOKEN(sym_text);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(31);
+          lookahead == ' ') ADVANCE(35);
       if (lookahead != 0 &&
           lookahead != '<' &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(85);
+          lookahead != '}') ADVANCE(98);
       END_STATE();
     default:
       return false;
@@ -994,84 +1141,93 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 33},
-  [2] = {.lex_state = 33},
-  [3] = {.lex_state = 33},
-  [4] = {.lex_state = 33},
-  [5] = {.lex_state = 33},
-  [6] = {.lex_state = 33},
-  [7] = {.lex_state = 33},
-  [8] = {.lex_state = 33},
-  [9] = {.lex_state = 33},
-  [10] = {.lex_state = 33},
-  [11] = {.lex_state = 33},
-  [12] = {.lex_state = 33},
-  [13] = {.lex_state = 33},
-  [14] = {.lex_state = 33},
-  [15] = {.lex_state = 33},
-  [16] = {.lex_state = 33},
-  [17] = {.lex_state = 33},
-  [18] = {.lex_state = 33},
-  [19] = {.lex_state = 33},
-  [20] = {.lex_state = 33},
-  [21] = {.lex_state = 33},
-  [22] = {.lex_state = 33},
-  [23] = {.lex_state = 33},
-  [24] = {.lex_state = 33},
-  [25] = {.lex_state = 33},
-  [26] = {.lex_state = 33},
-  [27] = {.lex_state = 33},
-  [28] = {.lex_state = 33},
-  [29] = {.lex_state = 33},
-  [30] = {.lex_state = 15},
-  [31] = {.lex_state = 15},
-  [32] = {.lex_state = 15},
-  [33] = {.lex_state = 15},
-  [34] = {.lex_state = 15},
-  [35] = {.lex_state = 1},
-  [36] = {.lex_state = 30},
-  [37] = {.lex_state = 30},
-  [38] = {.lex_state = 15},
-  [39] = {.lex_state = 30},
-  [40] = {.lex_state = 15},
-  [41] = {.lex_state = 30},
-  [42] = {.lex_state = 15},
-  [43] = {.lex_state = 15},
-  [44] = {.lex_state = 30},
-  [45] = {.lex_state = 15},
-  [46] = {.lex_state = 15},
-  [47] = {.lex_state = 11},
-  [48] = {.lex_state = 3},
-  [49] = {.lex_state = 3},
-  [50] = {.lex_state = 11},
-  [51] = {.lex_state = 13},
-  [52] = {.lex_state = 30},
-  [53] = {.lex_state = 30},
-  [54] = {.lex_state = 3},
-  [55] = {.lex_state = 13},
-  [56] = {.lex_state = 30},
-  [57] = {.lex_state = 12},
-  [58] = {.lex_state = 7},
-  [59] = {.lex_state = 12},
-  [60] = {.lex_state = 4},
-  [61] = {.lex_state = 32},
-  [62] = {.lex_state = 3},
-  [63] = {.lex_state = 2},
-  [64] = {.lex_state = 4},
-  [65] = {.lex_state = 0},
-  [66] = {.lex_state = 0},
+  [1] = {.lex_state = 37},
+  [2] = {.lex_state = 37},
+  [3] = {.lex_state = 37},
+  [4] = {.lex_state = 37},
+  [5] = {.lex_state = 37},
+  [6] = {.lex_state = 37},
+  [7] = {.lex_state = 37},
+  [8] = {.lex_state = 37},
+  [9] = {.lex_state = 37},
+  [10] = {.lex_state = 37},
+  [11] = {.lex_state = 37},
+  [12] = {.lex_state = 37},
+  [13] = {.lex_state = 37},
+  [14] = {.lex_state = 37},
+  [15] = {.lex_state = 37},
+  [16] = {.lex_state = 37},
+  [17] = {.lex_state = 37},
+  [18] = {.lex_state = 37},
+  [19] = {.lex_state = 37},
+  [20] = {.lex_state = 37},
+  [21] = {.lex_state = 37},
+  [22] = {.lex_state = 37},
+  [23] = {.lex_state = 37},
+  [24] = {.lex_state = 37},
+  [25] = {.lex_state = 37},
+  [26] = {.lex_state = 37},
+  [27] = {.lex_state = 37},
+  [28] = {.lex_state = 37},
+  [29] = {.lex_state = 37},
+  [30] = {.lex_state = 17},
+  [31] = {.lex_state = 17},
+  [32] = {.lex_state = 3},
+  [33] = {.lex_state = 17},
+  [34] = {.lex_state = 17},
+  [35] = {.lex_state = 17},
+  [36] = {.lex_state = 1},
+  [37] = {.lex_state = 34},
+  [38] = {.lex_state = 17},
+  [39] = {.lex_state = 5},
+  [40] = {.lex_state = 34},
+  [41] = {.lex_state = 5},
+  [42] = {.lex_state = 34},
+  [43] = {.lex_state = 17},
+  [44] = {.lex_state = 34},
+  [45] = {.lex_state = 17},
+  [46] = {.lex_state = 17},
+  [47] = {.lex_state = 17},
+  [48] = {.lex_state = 34},
+  [49] = {.lex_state = 17},
+  [50] = {.lex_state = 13},
+  [51] = {.lex_state = 6},
+  [52] = {.lex_state = 15},
+  [53] = {.lex_state = 13},
+  [54] = {.lex_state = 6},
+  [55] = {.lex_state = 34},
+  [56] = {.lex_state = 6},
+  [57] = {.lex_state = 34},
+  [58] = {.lex_state = 6},
+  [59] = {.lex_state = 6},
+  [60] = {.lex_state = 34},
+  [61] = {.lex_state = 6},
+  [62] = {.lex_state = 6},
+  [63] = {.lex_state = 15},
+  [64] = {.lex_state = 6},
+  [65] = {.lex_state = 14},
+  [66] = {.lex_state = 4},
   [67] = {.lex_state = 0},
-  [68] = {.lex_state = 32},
-  [69] = {.lex_state = 32},
+  [68] = {.lex_state = 36},
+  [69] = {.lex_state = 14},
   [70] = {.lex_state = 0},
-  [71] = {.lex_state = 0},
-  [72] = {.lex_state = 0},
-  [73] = {.lex_state = 26},
+  [71] = {.lex_state = 9},
+  [72] = {.lex_state = 2},
+  [73] = {.lex_state = 0},
   [74] = {.lex_state = 0},
   [75] = {.lex_state = 0},
-  [76] = {.lex_state = 0},
+  [76] = {.lex_state = 36},
   [77] = {.lex_state = 0},
   [78] = {.lex_state = 0},
+  [79] = {.lex_state = 0},
+  [80] = {.lex_state = 0},
+  [81] = {.lex_state = 0},
+  [82] = {.lex_state = 0},
+  [83] = {.lex_state = 0},
+  [84] = {.lex_state = 0},
+  [85] = {.lex_state = 0},
+  [86] = {.lex_state = 36},
+  [87] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1099,16 +1255,19 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LT_PERCENT_BANG_DASH_DASH] = ACTIONS(1),
     [anon_sym_DASH_DASH_PERCENT_GT] = ACTIONS(1),
     [anon_sym_LT_PERCENT_POUND] = ACTIONS(1),
-    [sym_tag_name] = ACTIONS(1),
+    [aux_sym_partial_expression_value_token1] = ACTIONS(1),
+    [anon_sym_do] = ACTIONS(1),
+    [anon_sym_DASH_GT] = ACTIONS(1),
+    [anon_sym_POUND] = ACTIONS(1),
   },
   [1] = {
-    [sym_fragment] = STATE(70),
+    [sym_fragment] = STATE(75),
     [sym__node] = STATE(7),
     [sym_doctype] = STATE(7),
     [sym_tag] = STATE(7),
     [sym_component] = STATE(7),
-    [sym_start_tag] = STATE(5),
-    [sym_self_closing_tag] = STATE(12),
+    [sym_start_tag] = STATE(6),
+    [sym_self_closing_tag] = STATE(11),
     [sym_start_component] = STATE(2),
     [sym_self_closing_component] = STATE(8),
     [sym_directive] = STATE(7),
@@ -1149,13 +1308,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_text,
     STATE(2), 1,
       sym_start_component,
-    STATE(5), 1,
+    STATE(6), 1,
       sym_start_tag,
     STATE(8), 1,
       sym_self_closing_component,
-    STATE(12), 1,
+    STATE(11), 1,
       sym_self_closing_tag,
-    STATE(22), 1,
+    STATE(21), 1,
       sym_end_component,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1192,13 +1351,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_text,
     STATE(2), 1,
       sym_start_component,
-    STATE(5), 1,
+    STATE(6), 1,
       sym_start_tag,
     STATE(8), 1,
       sym_self_closing_component,
-    STATE(12), 1,
+    STATE(11), 1,
       sym_self_closing_tag,
-    STATE(15), 1,
+    STATE(23), 1,
       sym_end_tag,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1210,7 +1369,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__html_comment,
       sym__bang_comment,
       sym__hash_comment,
-    STATE(6), 7,
+    STATE(5), 7,
       sym__node,
       sym_doctype,
       sym_tag,
@@ -1235,14 +1394,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_text,
     STATE(2), 1,
       sym_start_component,
-    STATE(5), 1,
+    STATE(6), 1,
       sym_start_tag,
     STATE(8), 1,
       sym_self_closing_component,
     STATE(11), 1,
-      sym_end_component,
-    STATE(12), 1,
       sym_self_closing_tag,
+    STATE(14), 1,
+      sym_end_component,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
       anon_sym_LT_PERCENT_PERCENT,
@@ -1253,7 +1412,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__html_comment,
       sym__bang_comment,
       sym__hash_comment,
-    STATE(6), 7,
+    STATE(5), 7,
       sym__node,
       sym_doctype,
       sym_tag,
@@ -1261,7 +1420,49 @@ static const uint16_t ts_small_parse_table[] = {
       sym_directive,
       sym_comment,
       aux_sym_fragment_repeat1,
-  [177] = 16,
+  [177] = 15,
+    ACTIONS(31), 1,
+      anon_sym_LT_BANG,
+    ACTIONS(34), 1,
+      anon_sym_LT,
+    ACTIONS(43), 1,
+      anon_sym_LT_BANG_DASH_DASH,
+    ACTIONS(46), 1,
+      anon_sym_LT_PERCENT_BANG_DASH_DASH,
+    ACTIONS(49), 1,
+      anon_sym_LT_PERCENT_POUND,
+    ACTIONS(52), 1,
+      sym_text,
+    STATE(2), 1,
+      sym_start_component,
+    STATE(6), 1,
+      sym_start_tag,
+    STATE(8), 1,
+      sym_self_closing_component,
+    STATE(11), 1,
+      sym_self_closing_tag,
+    ACTIONS(29), 2,
+      ts_builtin_sym_end,
+      anon_sym_LT_SLASH,
+    ACTIONS(37), 2,
+      anon_sym_LT_PERCENT,
+      anon_sym_LT_PERCENT_PERCENT,
+    ACTIONS(40), 2,
+      anon_sym_LT_PERCENT_EQ,
+      anon_sym_LT_PERCENT_PERCENT_EQ,
+    STATE(13), 3,
+      sym__html_comment,
+      sym__bang_comment,
+      sym__hash_comment,
+    STATE(5), 7,
+      sym__node,
+      sym_doctype,
+      sym_tag,
+      sym_component,
+      sym_directive,
+      sym_comment,
+      aux_sym_fragment_repeat1,
+  [234] = 16,
     ACTIONS(5), 1,
       anon_sym_LT_BANG,
     ACTIONS(7), 1,
@@ -1274,17 +1475,17 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LT_PERCENT_POUND,
     ACTIONS(25), 1,
       anon_sym_LT_SLASH,
-    ACTIONS(29), 1,
+    ACTIONS(55), 1,
       sym_text,
     STATE(2), 1,
       sym_start_component,
-    STATE(5), 1,
+    STATE(6), 1,
       sym_start_tag,
     STATE(8), 1,
       sym_self_closing_component,
-    STATE(12), 1,
+    STATE(11), 1,
       sym_self_closing_tag,
-    STATE(24), 1,
+    STATE(12), 1,
       sym_end_tag,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1297,48 +1498,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym__bang_comment,
       sym__hash_comment,
     STATE(3), 7,
-      sym__node,
-      sym_doctype,
-      sym_tag,
-      sym_component,
-      sym_directive,
-      sym_comment,
-      aux_sym_fragment_repeat1,
-  [236] = 15,
-    ACTIONS(33), 1,
-      anon_sym_LT_BANG,
-    ACTIONS(36), 1,
-      anon_sym_LT,
-    ACTIONS(45), 1,
-      anon_sym_LT_BANG_DASH_DASH,
-    ACTIONS(48), 1,
-      anon_sym_LT_PERCENT_BANG_DASH_DASH,
-    ACTIONS(51), 1,
-      anon_sym_LT_PERCENT_POUND,
-    ACTIONS(54), 1,
-      sym_text,
-    STATE(2), 1,
-      sym_start_component,
-    STATE(5), 1,
-      sym_start_tag,
-    STATE(8), 1,
-      sym_self_closing_component,
-    STATE(12), 1,
-      sym_self_closing_tag,
-    ACTIONS(31), 2,
-      ts_builtin_sym_end,
-      anon_sym_LT_SLASH,
-    ACTIONS(39), 2,
-      anon_sym_LT_PERCENT,
-      anon_sym_LT_PERCENT_PERCENT,
-    ACTIONS(42), 2,
-      anon_sym_LT_PERCENT_EQ,
-      anon_sym_LT_PERCENT_PERCENT_EQ,
-    STATE(13), 3,
-      sym__html_comment,
-      sym__bang_comment,
-      sym__hash_comment,
-    STATE(6), 7,
       sym__node,
       sym_doctype,
       sym_tag,
@@ -1363,11 +1522,11 @@ static const uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
     STATE(2), 1,
       sym_start_component,
-    STATE(5), 1,
+    STATE(6), 1,
       sym_start_tag,
     STATE(8), 1,
       sym_self_closing_component,
-    STATE(12), 1,
+    STATE(11), 1,
       sym_self_closing_tag,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1379,7 +1538,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__html_comment,
       sym__bang_comment,
       sym__hash_comment,
-    STATE(6), 7,
+    STATE(5), 7,
       sym__node,
       sym_doctype,
       sym_tag,
@@ -1722,7 +1881,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
     ACTIONS(153), 1,
       sym_attribute_name,
-    STATE(33), 3,
+    STATE(31), 3,
       sym_expression,
       sym_attribute,
       aux_sym_start_tag_repeat1,
@@ -1739,26 +1898,26 @@ static const uint16_t ts_small_parse_table[] = {
       sym_attribute,
       aux_sym_start_tag_repeat1,
   [753] = 5,
-    ACTIONS(151), 1,
-      anon_sym_LBRACE,
-    ACTIONS(153), 1,
-      sym_attribute_name,
     ACTIONS(163), 1,
-      anon_sym_GT,
-    ACTIONS(165), 1,
-      anon_sym_SLASH_GT,
-    STATE(31), 3,
-      sym_expression,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
+      aux_sym_partial_expression_value_token1,
+    ACTIONS(167), 1,
+      sym__code,
+    STATE(39), 1,
+      aux_sym__hash_comment_repeat1,
+    ACTIONS(165), 2,
+      anon_sym_do,
+      anon_sym_DASH_GT,
+    STATE(74), 2,
+      sym_expression_value,
+      sym_partial_expression_value,
   [771] = 5,
     ACTIONS(151), 1,
       anon_sym_LBRACE,
     ACTIONS(153), 1,
       sym_attribute_name,
-    ACTIONS(167), 1,
-      anon_sym_GT,
     ACTIONS(169), 1,
+      anon_sym_GT,
+    ACTIONS(171), 1,
       anon_sym_SLASH_GT,
     STATE(31), 3,
       sym_expression,
@@ -1769,262 +1928,333 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LBRACE,
     ACTIONS(153), 1,
       sym_attribute_name,
-    ACTIONS(171), 1,
-      anon_sym_GT,
     ACTIONS(173), 1,
+      anon_sym_GT,
+    ACTIONS(175), 1,
       anon_sym_SLASH_GT,
-    STATE(32), 3,
+    STATE(33), 3,
       sym_expression,
       sym_attribute,
       aux_sym_start_tag_repeat1,
   [807] = 5,
     ACTIONS(151), 1,
       anon_sym_LBRACE,
-    ACTIONS(175), 1,
-      sym_attribute_value,
+    ACTIONS(153), 1,
+      sym_attribute_name,
     ACTIONS(177), 1,
-      anon_sym_SQUOTE,
+      anon_sym_GT,
     ACTIONS(179), 1,
+      anon_sym_SLASH_GT,
+    STATE(30), 3,
+      sym_expression,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [825] = 5,
+    ACTIONS(151), 1,
+      anon_sym_LBRACE,
+    ACTIONS(181), 1,
+      sym_attribute_value,
+    ACTIONS(183), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(185), 1,
       anon_sym_DQUOTE,
-    STATE(40), 2,
+    STATE(46), 2,
       sym_expression,
       sym_quoted_attribute_value,
-  [824] = 5,
-    ACTIONS(181), 1,
+  [842] = 5,
+    ACTIONS(187), 1,
       anon_sym_LBRACE,
-    ACTIONS(184), 1,
-      anon_sym_RBRACE,
-    ACTIONS(186), 1,
-      aux_sym__expression_value_token1,
-    STATE(36), 1,
-      aux_sym_expression_repeat1,
-    STATE(53), 1,
-      sym__expression_value,
-  [840] = 5,
     ACTIONS(189), 1,
+      anon_sym_RBRACE,
+    ACTIONS(191), 1,
+      aux_sym__expression_value_token1,
+    STATE(42), 1,
+      aux_sym_expression_repeat1,
+    STATE(57), 1,
+      sym__expression_value,
+  [858] = 2,
+    ACTIONS(195), 1,
+      anon_sym_EQ,
+    ACTIONS(193), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [868] = 4,
+    ACTIONS(197), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(201), 1,
+      sym__code,
+    STATE(41), 1,
+      aux_sym__hash_comment_repeat1,
+    ACTIONS(199), 2,
+      anon_sym_do,
+      anon_sym_DASH_GT,
+  [882] = 5,
+    ACTIONS(187), 1,
       anon_sym_LBRACE,
     ACTIONS(191), 1,
-      anon_sym_RBRACE,
-    ACTIONS(193), 1,
       aux_sym__expression_value_token1,
-    STATE(39), 1,
-      aux_sym_expression_repeat1,
-    STATE(53), 1,
-      sym__expression_value,
-  [856] = 2,
-    ACTIONS(197), 1,
-      anon_sym_EQ,
-    ACTIONS(195), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [866] = 5,
-    ACTIONS(189), 1,
-      anon_sym_LBRACE,
-    ACTIONS(193), 1,
-      aux_sym__expression_value_token1,
-    ACTIONS(199), 1,
-      anon_sym_RBRACE,
-    STATE(36), 1,
-      aux_sym_expression_repeat1,
-    STATE(53), 1,
-      sym__expression_value,
-  [882] = 1,
-    ACTIONS(201), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [889] = 4,
     ACTIONS(203), 1,
-      anon_sym_LBRACE,
-    ACTIONS(205), 1,
       anon_sym_RBRACE,
+    STATE(37), 1,
+      aux_sym_expression_repeat1,
+    STATE(57), 1,
+      sym__expression_value,
+  [898] = 3,
     ACTIONS(207), 1,
-      aux_sym__expression_value_token1,
-    STATE(78), 1,
-      sym__expression_value,
-  [902] = 1,
-    ACTIONS(209), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [909] = 1,
-    ACTIONS(211), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [916] = 4,
-    ACTIONS(203), 1,
+      sym__code,
+    STATE(41), 1,
+      aux_sym__hash_comment_repeat1,
+    ACTIONS(205), 3,
+      anon_sym_PERCENT_GT,
+      anon_sym_do,
+      anon_sym_DASH_GT,
+  [910] = 5,
+    ACTIONS(210), 1,
       anon_sym_LBRACE,
     ACTIONS(213), 1,
       anon_sym_RBRACE,
     ACTIONS(215), 1,
       aux_sym__expression_value_token1,
-    STATE(65), 1,
+    STATE(42), 1,
+      aux_sym_expression_repeat1,
+    STATE(57), 1,
       sym__expression_value,
-  [929] = 1,
-    ACTIONS(217), 4,
+  [926] = 1,
+    ACTIONS(218), 4,
       anon_sym_GT,
       anon_sym_SLASH_GT,
       anon_sym_LBRACE,
       sym_attribute_name,
-  [936] = 1,
-    ACTIONS(219), 4,
+  [933] = 4,
+    ACTIONS(220), 1,
+      anon_sym_LBRACE,
+    ACTIONS(222), 1,
+      anon_sym_RBRACE,
+    ACTIONS(224), 1,
+      aux_sym__expression_value_token1,
+    STATE(81), 1,
+      sym__expression_value,
+  [946] = 1,
+    ACTIONS(226), 4,
       anon_sym_GT,
       anon_sym_SLASH_GT,
       anon_sym_LBRACE,
       sym_attribute_name,
-  [943] = 3,
-    ACTIONS(221), 1,
-      aux_sym__html_comment_token1,
-    ACTIONS(223), 1,
-      anon_sym_DASH_DASH_GT,
-    STATE(50), 1,
-      aux_sym__html_comment_repeat1,
-  [953] = 3,
-    ACTIONS(225), 1,
-      aux_sym_directive_token1,
-    ACTIONS(228), 1,
-      anon_sym_PERCENT_GT,
-    STATE(48), 1,
-      aux_sym_directive_repeat1,
-  [963] = 3,
-    ACTIONS(230), 1,
-      aux_sym_directive_token1,
+  [953] = 1,
+    ACTIONS(228), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [960] = 1,
+    ACTIONS(230), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [967] = 4,
+    ACTIONS(220), 1,
+      anon_sym_LBRACE,
     ACTIONS(232), 1,
-      anon_sym_PERCENT_GT,
-    STATE(48), 1,
-      aux_sym_directive_repeat1,
-  [973] = 3,
+      anon_sym_RBRACE,
     ACTIONS(234), 1,
+      aux_sym__expression_value_token1,
+    STATE(87), 1,
+      sym__expression_value,
+  [980] = 1,
+    ACTIONS(236), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [987] = 3,
+    ACTIONS(238), 1,
       aux_sym__html_comment_token1,
-    ACTIONS(237), 1,
+    ACTIONS(240), 1,
       anon_sym_DASH_DASH_GT,
+    STATE(53), 1,
+      aux_sym__html_comment_repeat1,
+  [997] = 3,
+    ACTIONS(242), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(244), 1,
+      sym__code,
+    STATE(54), 1,
+      aux_sym__hash_comment_repeat1,
+  [1007] = 3,
+    ACTIONS(246), 1,
+      aux_sym__html_comment_token1,
+    ACTIONS(249), 1,
+      anon_sym_DASH_DASH_PERCENT_GT,
+    STATE(52), 1,
+      aux_sym__html_comment_repeat1,
+  [1017] = 3,
+    ACTIONS(249), 1,
+      anon_sym_DASH_DASH_GT,
+    ACTIONS(251), 1,
+      aux_sym__html_comment_token1,
+    STATE(53), 1,
+      aux_sym__html_comment_repeat1,
+  [1027] = 3,
+    ACTIONS(205), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(254), 1,
+      sym__code,
+    STATE(54), 1,
+      aux_sym__hash_comment_repeat1,
+  [1037] = 2,
+    ACTIONS(259), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(257), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [1045] = 3,
+    ACTIONS(261), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(263), 1,
+      sym__code,
+    STATE(51), 1,
+      aux_sym__hash_comment_repeat1,
+  [1055] = 2,
+    ACTIONS(267), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(265), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [1063] = 3,
+    ACTIONS(244), 1,
+      sym__code,
+    ACTIONS(261), 1,
+      anon_sym_PERCENT_GT,
+    STATE(54), 1,
+      aux_sym__hash_comment_repeat1,
+  [1073] = 3,
+    ACTIONS(244), 1,
+      sym__code,
+    ACTIONS(269), 1,
+      anon_sym_PERCENT_GT,
+    STATE(54), 1,
+      aux_sym__hash_comment_repeat1,
+  [1083] = 2,
+    ACTIONS(273), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(271), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [1091] = 3,
+    ACTIONS(275), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(277), 1,
+      sym__code,
+    STATE(58), 1,
+      aux_sym__hash_comment_repeat1,
+  [1101] = 3,
+    ACTIONS(244), 1,
+      sym__code,
+    ACTIONS(279), 1,
+      anon_sym_PERCENT_GT,
+    STATE(54), 1,
+      aux_sym__hash_comment_repeat1,
+  [1111] = 3,
+    ACTIONS(281), 1,
+      aux_sym__html_comment_token1,
+    ACTIONS(283), 1,
+      anon_sym_DASH_DASH_PERCENT_GT,
+    STATE(52), 1,
+      aux_sym__html_comment_repeat1,
+  [1121] = 3,
+    ACTIONS(242), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(285), 1,
+      sym__code,
+    STATE(59), 1,
+      aux_sym__hash_comment_repeat1,
+  [1131] = 2,
+    ACTIONS(287), 1,
+      aux_sym__html_comment_token1,
+    STATE(63), 1,
+      aux_sym__html_comment_repeat1,
+  [1138] = 2,
+    ACTIONS(289), 1,
+      sym__code,
+    STATE(62), 1,
+      aux_sym__hash_comment_repeat1,
+  [1145] = 2,
+    ACTIONS(291), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(293), 1,
+      anon_sym_POUND,
+  [1152] = 2,
+    ACTIONS(295), 1,
+      sym_tag_name,
+    ACTIONS(297), 1,
+      sym_component_name,
+  [1159] = 2,
+    ACTIONS(299), 1,
+      aux_sym__html_comment_token1,
     STATE(50), 1,
       aux_sym__html_comment_repeat1,
-  [983] = 3,
-    ACTIONS(237), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    ACTIONS(239), 1,
-      aux_sym__html_comment_token1,
-    STATE(51), 1,
-      aux_sym__html_comment_repeat1,
-  [993] = 2,
-    ACTIONS(244), 1,
-      aux_sym__expression_value_token1,
-    ACTIONS(242), 2,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-  [1001] = 2,
-    ACTIONS(248), 1,
-      aux_sym__expression_value_token1,
-    ACTIONS(246), 2,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-  [1009] = 3,
-    ACTIONS(230), 1,
-      aux_sym_directive_token1,
-    ACTIONS(250), 1,
+  [1166] = 2,
+    ACTIONS(301), 1,
       anon_sym_PERCENT_GT,
-    STATE(48), 1,
-      aux_sym_directive_repeat1,
-  [1019] = 3,
-    ACTIONS(252), 1,
-      aux_sym__html_comment_token1,
-    ACTIONS(254), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(51), 1,
-      aux_sym__html_comment_repeat1,
-  [1029] = 2,
-    ACTIONS(258), 1,
-      aux_sym__expression_value_token1,
-    ACTIONS(256), 2,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-  [1037] = 2,
-    ACTIONS(260), 1,
-      aux_sym__html_comment_token1,
-    STATE(47), 1,
-      aux_sym__html_comment_repeat1,
-  [1044] = 2,
-    ACTIONS(262), 1,
+    ACTIONS(303), 1,
+      anon_sym_POUND,
+  [1173] = 2,
+    ACTIONS(305), 1,
       anon_sym_SQUOTE,
-    ACTIONS(264), 1,
+    ACTIONS(307), 1,
       aux_sym_quoted_attribute_value_token1,
-  [1051] = 2,
-    ACTIONS(266), 1,
-      aux_sym__html_comment_token1,
-    STATE(55), 1,
-      aux_sym__html_comment_repeat1,
-  [1058] = 2,
-    ACTIONS(268), 1,
-      aux_sym_directive_token1,
-    STATE(49), 1,
-      aux_sym_directive_repeat1,
-  [1065] = 2,
-    ACTIONS(270), 1,
-      sym_tag_name,
-    ACTIONS(272), 1,
-      sym_component_name,
-  [1072] = 1,
-    ACTIONS(274), 2,
-      aux_sym_directive_token1,
-      anon_sym_PERCENT_GT,
-  [1077] = 2,
-    ACTIONS(262), 1,
+  [1180] = 2,
+    ACTIONS(305), 1,
       anon_sym_DQUOTE,
-    ACTIONS(276), 1,
+    ACTIONS(309), 1,
       aux_sym_quoted_attribute_value_token2,
-  [1084] = 2,
-    ACTIONS(268), 1,
-      aux_sym_directive_token1,
-    STATE(54), 1,
-      aux_sym_directive_repeat1,
-  [1091] = 1,
-    ACTIONS(278), 1,
-      anon_sym_RBRACE,
-  [1095] = 1,
-    ACTIONS(280), 1,
-      anon_sym_DOCTYPE,
-  [1099] = 1,
-    ACTIONS(282), 1,
-      anon_sym_GT,
-  [1103] = 1,
-    ACTIONS(284), 1,
-      sym_component_name,
-  [1107] = 1,
-    ACTIONS(286), 1,
-      sym_tag_name,
-  [1111] = 1,
-    ACTIONS(288), 1,
-      ts_builtin_sym_end,
-  [1115] = 1,
-    ACTIONS(290), 1,
-      anon_sym_SQUOTE,
-  [1119] = 1,
-    ACTIONS(290), 1,
-      anon_sym_DQUOTE,
-  [1123] = 1,
-    ACTIONS(292), 1,
+  [1187] = 1,
+    ACTIONS(311), 1,
       anon_sym_html,
-  [1127] = 1,
-    ACTIONS(294), 1,
+  [1191] = 1,
+    ACTIONS(313), 1,
+      anon_sym_PERCENT_GT,
+  [1195] = 1,
+    ACTIONS(315), 1,
+      ts_builtin_sym_end,
+  [1199] = 1,
+    ACTIONS(317), 1,
+      sym_component_name,
+  [1203] = 1,
+    ACTIONS(319), 1,
       anon_sym_GT,
-  [1131] = 1,
-    ACTIONS(258), 1,
-      anon_sym_RBRACE,
-  [1135] = 1,
-    ACTIONS(244), 1,
-      anon_sym_RBRACE,
-  [1139] = 1,
-    ACTIONS(296), 1,
+  [1207] = 1,
+    ACTIONS(321), 1,
       anon_sym_GT,
-  [1143] = 1,
-    ACTIONS(298), 1,
+  [1211] = 1,
+    ACTIONS(323), 1,
+      anon_sym_SQUOTE,
+  [1215] = 1,
+    ACTIONS(323), 1,
+      anon_sym_DQUOTE,
+  [1219] = 1,
+    ACTIONS(325), 1,
+      anon_sym_RBRACE,
+  [1223] = 1,
+    ACTIONS(327), 1,
+      anon_sym_DOCTYPE,
+  [1227] = 1,
+    ACTIONS(329), 1,
+      anon_sym_GT,
+  [1231] = 1,
+    ACTIONS(273), 1,
+      anon_sym_RBRACE,
+  [1235] = 1,
+    ACTIONS(259), 1,
+      anon_sym_RBRACE,
+  [1239] = 1,
+    ACTIONS(331), 1,
+      sym_tag_name,
+  [1243] = 1,
+    ACTIONS(333), 1,
       anon_sym_RBRACE,
 };
 
@@ -2033,7 +2263,7 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(3)] = 59,
   [SMALL_STATE(4)] = 118,
   [SMALL_STATE(5)] = 177,
-  [SMALL_STATE(6)] = 236,
+  [SMALL_STATE(6)] = 234,
   [SMALL_STATE(7)] = 293,
   [SMALL_STATE(8)] = 349,
   [SMALL_STATE(9)] = 366,
@@ -2063,195 +2293,221 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(33)] = 771,
   [SMALL_STATE(34)] = 789,
   [SMALL_STATE(35)] = 807,
-  [SMALL_STATE(36)] = 824,
-  [SMALL_STATE(37)] = 840,
-  [SMALL_STATE(38)] = 856,
-  [SMALL_STATE(39)] = 866,
+  [SMALL_STATE(36)] = 825,
+  [SMALL_STATE(37)] = 842,
+  [SMALL_STATE(38)] = 858,
+  [SMALL_STATE(39)] = 868,
   [SMALL_STATE(40)] = 882,
-  [SMALL_STATE(41)] = 889,
-  [SMALL_STATE(42)] = 902,
-  [SMALL_STATE(43)] = 909,
-  [SMALL_STATE(44)] = 916,
-  [SMALL_STATE(45)] = 929,
-  [SMALL_STATE(46)] = 936,
-  [SMALL_STATE(47)] = 943,
-  [SMALL_STATE(48)] = 953,
-  [SMALL_STATE(49)] = 963,
-  [SMALL_STATE(50)] = 973,
-  [SMALL_STATE(51)] = 983,
-  [SMALL_STATE(52)] = 993,
-  [SMALL_STATE(53)] = 1001,
-  [SMALL_STATE(54)] = 1009,
-  [SMALL_STATE(55)] = 1019,
-  [SMALL_STATE(56)] = 1029,
-  [SMALL_STATE(57)] = 1037,
-  [SMALL_STATE(58)] = 1044,
-  [SMALL_STATE(59)] = 1051,
-  [SMALL_STATE(60)] = 1058,
-  [SMALL_STATE(61)] = 1065,
-  [SMALL_STATE(62)] = 1072,
-  [SMALL_STATE(63)] = 1077,
-  [SMALL_STATE(64)] = 1084,
-  [SMALL_STATE(65)] = 1091,
-  [SMALL_STATE(66)] = 1095,
-  [SMALL_STATE(67)] = 1099,
-  [SMALL_STATE(68)] = 1103,
-  [SMALL_STATE(69)] = 1107,
-  [SMALL_STATE(70)] = 1111,
-  [SMALL_STATE(71)] = 1115,
-  [SMALL_STATE(72)] = 1119,
-  [SMALL_STATE(73)] = 1123,
-  [SMALL_STATE(74)] = 1127,
-  [SMALL_STATE(75)] = 1131,
-  [SMALL_STATE(76)] = 1135,
-  [SMALL_STATE(77)] = 1139,
-  [SMALL_STATE(78)] = 1143,
+  [SMALL_STATE(41)] = 898,
+  [SMALL_STATE(42)] = 910,
+  [SMALL_STATE(43)] = 926,
+  [SMALL_STATE(44)] = 933,
+  [SMALL_STATE(45)] = 946,
+  [SMALL_STATE(46)] = 953,
+  [SMALL_STATE(47)] = 960,
+  [SMALL_STATE(48)] = 967,
+  [SMALL_STATE(49)] = 980,
+  [SMALL_STATE(50)] = 987,
+  [SMALL_STATE(51)] = 997,
+  [SMALL_STATE(52)] = 1007,
+  [SMALL_STATE(53)] = 1017,
+  [SMALL_STATE(54)] = 1027,
+  [SMALL_STATE(55)] = 1037,
+  [SMALL_STATE(56)] = 1045,
+  [SMALL_STATE(57)] = 1055,
+  [SMALL_STATE(58)] = 1063,
+  [SMALL_STATE(59)] = 1073,
+  [SMALL_STATE(60)] = 1083,
+  [SMALL_STATE(61)] = 1091,
+  [SMALL_STATE(62)] = 1101,
+  [SMALL_STATE(63)] = 1111,
+  [SMALL_STATE(64)] = 1121,
+  [SMALL_STATE(65)] = 1131,
+  [SMALL_STATE(66)] = 1138,
+  [SMALL_STATE(67)] = 1145,
+  [SMALL_STATE(68)] = 1152,
+  [SMALL_STATE(69)] = 1159,
+  [SMALL_STATE(70)] = 1166,
+  [SMALL_STATE(71)] = 1173,
+  [SMALL_STATE(72)] = 1180,
+  [SMALL_STATE(73)] = 1187,
+  [SMALL_STATE(74)] = 1191,
+  [SMALL_STATE(75)] = 1195,
+  [SMALL_STATE(76)] = 1199,
+  [SMALL_STATE(77)] = 1203,
+  [SMALL_STATE(78)] = 1207,
+  [SMALL_STATE(79)] = 1211,
+  [SMALL_STATE(80)] = 1215,
+  [SMALL_STATE(81)] = 1219,
+  [SMALL_STATE(82)] = 1223,
+  [SMALL_STATE(83)] = 1227,
+  [SMALL_STATE(84)] = 1231,
+  [SMALL_STATE(85)] = 1235,
+  [SMALL_STATE(86)] = 1239,
+  [SMALL_STATE(87)] = 1243,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
   [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
   [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
-  [33] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(66),
-  [36] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(61),
-  [39] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(60),
-  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(60),
-  [45] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(57),
-  [48] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(59),
-  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(64),
-  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(6),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
+  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(82),
+  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(68),
+  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(32),
+  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(32),
+  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(69),
+  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(65),
+  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(66),
+  [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(5),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
   [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1),
   [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 1),
   [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 1),
-  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4),
-  [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4),
-  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctype, 4),
-  [69] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctype, 4),
-  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 3),
-  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 3),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 1),
-  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 1),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
+  [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
+  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 3),
+  [69] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 3),
+  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 1),
+  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 1),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
+  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
   [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1),
   [81] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 1),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_component, 3),
-  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_component, 3),
-  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
-  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 3),
-  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 3),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 3),
-  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 3),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__html_comment, 3),
-  [101] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__html_comment, 3),
-  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3, .production_id = 1),
-  [105] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3, .production_id = 1),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 3),
-  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 3),
-  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3),
-  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3),
-  [115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 2),
-  [117] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 2),
-  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 4),
-  [121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 4),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
-  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3),
-  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_tag, 3),
-  [131] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 4),
-  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 4),
-  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 4),
-  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 4),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 3),
+  [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 3),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_component, 3),
+  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_component, 3),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3),
+  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__html_comment, 3),
+  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__html_comment, 3),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3),
+  [101] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_tag, 3),
+  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 4),
+  [105] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 4),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 3),
+  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 3),
+  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 2),
+  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 2),
+  [115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 3),
+  [117] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 3),
+  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
+  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4),
+  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4),
+  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctype, 4),
+  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctype, 4),
+  [131] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 4),
+  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 4),
+  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 4),
+  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 4),
   [139] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 3),
   [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 3),
   [143] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 3),
   [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 3),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
   [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
   [155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2),
-  [157] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(37),
+  [157] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(40),
   [160] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(38),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [181] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(44),
-  [184] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2),
-  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(53),
-  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [191] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 1),
-  [197] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3),
-  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [205] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
-  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3),
-  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2),
-  [213] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 2),
-  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3, .production_id = 1),
-  [221] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
-  [223] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [225] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2), SHIFT_REPEAT(62),
-  [228] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 2),
-  [230] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [232] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
-  [234] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(50),
-  [237] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2),
-  [239] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(51),
-  [242] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 3),
-  [244] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 3),
-  [246] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 1),
-  [248] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 1),
-  [250] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [252] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [254] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [256] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 2),
-  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 2),
-  [260] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [262] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [274] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_directive_repeat1, 1),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [284] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [288] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [163] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
+  [165] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
+  [167] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 1),
+  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression_value, 1),
+  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
+  [201] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [205] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2),
+  [207] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2), SHIFT_REPEAT(41),
+  [210] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(44),
+  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2),
+  [215] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(57),
+  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 2),
+  [220] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [222] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
+  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3, .production_id = 1),
+  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3),
+  [230] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2),
+  [232] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
+  [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3),
+  [238] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
+  [240] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [242] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 3),
+  [244] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [246] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(52),
+  [249] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2),
+  [251] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(53),
+  [254] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2), SHIFT_REPEAT(54),
+  [257] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 3),
+  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 3),
+  [261] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 2),
+  [263] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [265] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 1),
+  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 1),
+  [269] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 4),
+  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 2),
+  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 2),
+  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 1),
+  [277] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [279] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [283] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [291] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression_value, 1),
+  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression_value, 2),
+  [303] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [305] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [311] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [315] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [317] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [319] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [329] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,11 +6,11 @@
 #endif
 
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 88
+#define STATE_COUNT 93
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 64
+#define SYMBOL_COUNT 67
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 37
+#define TOKEN_COUNT 39
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
@@ -48,38 +48,41 @@ enum {
   anon_sym_do = 29,
   anon_sym_DASH_GT = 30,
   anon_sym_POUND = 31,
-  sym__code = 32,
-  sym_tag_name = 33,
-  sym_component_name = 34,
-  sym_attribute_name = 35,
-  sym_text = 36,
-  sym_fragment = 37,
-  sym__node = 38,
-  sym_doctype = 39,
-  sym_tag = 40,
-  sym_component = 41,
-  sym_start_tag = 42,
-  sym_end_tag = 43,
-  sym_self_closing_tag = 44,
-  sym_start_component = 45,
-  sym_end_component = 46,
-  sym_self_closing_component = 47,
-  sym_expression = 48,
-  sym__expression_value = 49,
-  sym_attribute = 50,
-  sym_quoted_attribute_value = 51,
-  sym_directive = 52,
-  sym_comment = 53,
-  sym__html_comment = 54,
-  sym__bang_comment = 55,
-  sym__hash_comment = 56,
-  sym_expression_value = 57,
-  sym_partial_expression_value = 58,
-  aux_sym_fragment_repeat1 = 59,
-  aux_sym_start_tag_repeat1 = 60,
-  aux_sym_expression_repeat1 = 61,
-  aux_sym__html_comment_repeat1 = 62,
-  aux_sym__hash_comment_repeat1 = 63,
+  anon_sym_DOT = 32,
+  sym_module = 33,
+  sym_function = 34,
+  sym__code = 35,
+  sym_tag_name = 36,
+  sym_attribute_name = 37,
+  sym_text = 38,
+  sym_fragment = 39,
+  sym__node = 40,
+  sym_doctype = 41,
+  sym_tag = 42,
+  sym_component = 43,
+  sym_start_tag = 44,
+  sym_end_tag = 45,
+  sym_self_closing_tag = 46,
+  sym_start_component = 47,
+  sym_end_component = 48,
+  sym_self_closing_component = 49,
+  sym_expression = 50,
+  sym__expression_value = 51,
+  sym_attribute = 52,
+  sym_quoted_attribute_value = 53,
+  sym_directive = 54,
+  sym_comment = 55,
+  sym__html_comment = 56,
+  sym__bang_comment = 57,
+  sym__hash_comment = 58,
+  sym_expression_value = 59,
+  sym_partial_expression_value = 60,
+  sym_component_name = 61,
+  aux_sym_fragment_repeat1 = 62,
+  aux_sym_start_tag_repeat1 = 63,
+  aux_sym_expression_repeat1 = 64,
+  aux_sym__html_comment_repeat1 = 65,
+  aux_sym__hash_comment_repeat1 = 66,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -115,9 +118,11 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_do] = "do",
   [anon_sym_DASH_GT] = "->",
   [anon_sym_POUND] = "#",
+  [anon_sym_DOT] = ".",
+  [sym_module] = "module",
+  [sym_function] = "function",
   [sym__code] = "_code",
   [sym_tag_name] = "tag_name",
-  [sym_component_name] = "component_name",
   [sym_attribute_name] = "attribute_name",
   [sym_text] = "text",
   [sym_fragment] = "fragment",
@@ -142,6 +147,7 @@ static const char * const ts_symbol_names[] = {
   [sym__hash_comment] = "_hash_comment",
   [sym_expression_value] = "expression_value",
   [sym_partial_expression_value] = "partial_expression_value",
+  [sym_component_name] = "component_name",
   [aux_sym_fragment_repeat1] = "fragment_repeat1",
   [aux_sym_start_tag_repeat1] = "start_tag_repeat1",
   [aux_sym_expression_repeat1] = "expression_repeat1",
@@ -182,9 +188,11 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_do] = anon_sym_do,
   [anon_sym_DASH_GT] = anon_sym_DASH_GT,
   [anon_sym_POUND] = anon_sym_POUND,
+  [anon_sym_DOT] = anon_sym_DOT,
+  [sym_module] = sym_module,
+  [sym_function] = sym_function,
   [sym__code] = sym__code,
   [sym_tag_name] = sym_tag_name,
-  [sym_component_name] = sym_component_name,
   [sym_attribute_name] = sym_attribute_name,
   [sym_text] = sym_text,
   [sym_fragment] = sym_fragment,
@@ -209,6 +217,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym__hash_comment] = sym__hash_comment,
   [sym_expression_value] = sym_expression_value,
   [sym_partial_expression_value] = sym_partial_expression_value,
+  [sym_component_name] = sym_component_name,
   [aux_sym_fragment_repeat1] = aux_sym_fragment_repeat1,
   [aux_sym_start_tag_repeat1] = aux_sym_start_tag_repeat1,
   [aux_sym_expression_repeat1] = aux_sym_expression_repeat1,
@@ -345,15 +354,23 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_DOT] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_module] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_function] = {
+    .visible = true,
+    .named = true,
+  },
   [sym__code] = {
     .visible = false,
     .named = true,
   },
   [sym_tag_name] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym_component_name] = {
     .visible = true,
     .named = true,
   },
@@ -453,6 +470,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_component_name] = {
+    .visible = true,
+    .named = true,
+  },
   [aux_sym_fragment_repeat1] = {
     .visible = false,
     .named = false,
@@ -503,6 +524,20 @@ static inline bool sym_attribute_value_character_set_1(int32_t c) {
       : (c <= '{' || c == '}'))));
 }
 
+static inline bool sym_module_character_set_1(int32_t c) {
+  return (c < '\''
+    ? (c < '\r'
+      ? (c < '\t'
+        ? c == 0
+        : c <= '\n')
+      : (c <= '\r' || (c >= ' ' && c <= '"')))
+    : (c <= '\'' || (c < '{'
+      ? (c < '<'
+        ? (c >= '-' && c <= '/')
+        : c <= '>')
+      : (c <= '{' || c == '}'))));
+}
+
 static inline bool sym_tag_name_character_set_1(int32_t c) {
   return (c < '-'
     ? (c < '\r'
@@ -515,20 +550,6 @@ static inline bool sym_tag_name_character_set_1(int32_t c) {
     : (c <= '-' || (c < '{'
       ? (c < '<'
         ? c == '/'
-        : c <= '>')
-      : (c <= '{' || c == '}'))));
-}
-
-static inline bool sym_component_name_character_set_1(int32_t c) {
-  return (c < '\''
-    ? (c < '\r'
-      ? (c < '\t'
-        ? c == 0
-        : c <= '\n')
-      : (c <= '\r' || (c >= ' ' && c <= '"')))
-    : (c <= '\'' || (c < '{'
-      ? (c < '<'
-        ? (c >= '-' && c <= '/')
         : c <= '>')
       : (c <= '{' || c == '}'))));
 }
@@ -554,141 +575,160 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(38);
-      if (lookahead == '"') ADVANCE(55);
-      if (lookahead == '#') ADVANCE(81);
-      if (lookahead == '%') ADVANCE(18);
-      if (lookahead == '\'') ADVANCE(52);
-      if (lookahead == '-') ADVANCE(10);
-      if (lookahead == '/') ADVANCE(19);
-      if (lookahead == '<') ADVANCE(43);
-      if (lookahead == '=') ADVANCE(50);
-      if (lookahead == '>') ADVANCE(42);
-      if (lookahead == 'D') ADVANCE(24);
-      if (lookahead == 'd') ADVANCE(32);
-      if (lookahead == 'e') ADVANCE(31);
-      if (lookahead == 'h') ADVANCE(33);
-      if (lookahead == '{') ADVANCE(46);
-      if (lookahead == '}') ADVANCE(47);
+      if (eof) ADVANCE(37);
+      if (lookahead == '"') ADVANCE(54);
+      if (lookahead == '#') ADVANCE(80);
+      if (lookahead == '\'') ADVANCE(51);
+      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '/') ADVANCE(18);
+      if (lookahead == '<') ADVANCE(42);
+      if (lookahead == '=') ADVANCE(49);
+      if (lookahead == '>') ADVANCE(41);
+      if (lookahead == 'D') ADVANCE(99);
+      if (lookahead == 'd') ADVANCE(107);
+      if (lookahead == 'e') ADVANCE(106);
+      if (lookahead == 'h') ADVANCE(108);
+      if (lookahead == '{') ADVANCE(45);
+      if (lookahead == '}') ADVANCE(46);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
+      if (lookahead != 0) ADVANCE(109);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(55);
-      if (lookahead == '\'') ADVANCE(52);
-      if (lookahead == '{') ADVANCE(46);
+      if (lookahead == '"') ADVANCE(54);
+      if (lookahead == '\'') ADVANCE(51);
+      if (lookahead == '{') ADVANCE(45);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(1)
       if (lookahead != 0 &&
           (lookahead < '<' || '>' < lookahead) &&
-          lookahead != '}') ADVANCE(51);
+          lookahead != '}') ADVANCE(50);
       END_STATE();
     case 2:
-      if (lookahead == '"') ADVANCE(55);
+      if (lookahead == '"') ADVANCE(54);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(56);
-      if (lookahead != 0) ADVANCE(57);
+          lookahead == ' ') ADVANCE(55);
+      if (lookahead != 0) ADVANCE(56);
       END_STATE();
     case 3:
-      if (lookahead == '%') ADVANCE(82);
-      if (lookahead == '-') ADVANCE(88);
-      if (lookahead == 'd') ADVANCE(91);
-      if (lookahead == 'e') ADVANCE(90);
+      if (lookahead == '#') ADVANCE(80);
+      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '.') ADVANCE(81);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(83);
-      if (lookahead != 0) ADVANCE(92);
+          lookahead == ' ') SKIP(3)
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(82);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
       END_STATE();
     case 4:
-      if (lookahead == '%') ADVANCE(82);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(84);
-      if (lookahead != 0) ADVANCE(92);
-      END_STATE();
-    case 5:
-      if (lookahead == '%') ADVANCE(87);
-      if (lookahead == '-') ADVANCE(88);
-      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == '%') ADVANCE(84);
+      if (lookahead == '-') ADVANCE(89);
+      if (lookahead == 'd') ADVANCE(93);
+      if (lookahead == 'e') ADVANCE(92);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(85);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(94);
       END_STATE();
-    case 6:
-      if (lookahead == '%') ADVANCE(87);
+    case 5:
+      if (lookahead == '%') ADVANCE(84);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(86);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(94);
+      END_STATE();
+    case 6:
+      if (lookahead == '%') ADVANCE(90);
+      if (lookahead == '-') ADVANCE(89);
+      if (lookahead == 'd') ADVANCE(93);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(87);
+      if (lookahead != 0) ADVANCE(94);
       END_STATE();
     case 7:
-      if (lookahead == '%') ADVANCE(21);
+      if (lookahead == '%') ADVANCE(90);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(88);
+      if (lookahead != 0) ADVANCE(94);
       END_STATE();
     case 8:
       if (lookahead == '%') ADVANCE(21);
-      if (lookahead == '>') ADVANCE(71);
       END_STATE();
     case 9:
-      if (lookahead == '\'') ADVANCE(52);
+      if (lookahead == '\'') ADVANCE(51);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(53);
-      if (lookahead != 0) ADVANCE(54);
+          lookahead == ' ') ADVANCE(52);
+      if (lookahead != 0) ADVANCE(53);
       END_STATE();
     case 10:
-      if (lookahead == '-') ADVANCE(8);
-      if (lookahead == '>') ADVANCE(79);
+      if (lookahead == '-') ADVANCE(62);
       END_STATE();
     case 11:
-      if (lookahead == '-') ADVANCE(63);
+      if (lookahead == '-') ADVANCE(71);
       END_STATE();
     case 12:
-      if (lookahead == '-') ADVANCE(72);
-      END_STATE();
-    case 13:
-      if (lookahead == '-') ADVANCE(69);
+      if (lookahead == '-') ADVANCE(68);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(65);
-      if (lookahead != 0) ADVANCE(70);
+          lookahead == ' ') ADVANCE(64);
+      if (lookahead != 0) ADVANCE(69);
+      END_STATE();
+    case 13:
+      if (lookahead == '-') ADVANCE(63);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(66);
+      if (lookahead != 0) ADVANCE(69);
       END_STATE();
     case 14:
-      if (lookahead == '-') ADVANCE(64);
+      if (lookahead == '-') ADVANCE(65);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(67);
-      if (lookahead != 0) ADVANCE(70);
+      if (lookahead != 0) ADVANCE(69);
       END_STATE();
     case 15:
-      if (lookahead == '-') ADVANCE(66);
+      if (lookahead == '-') ADVANCE(11);
+      END_STATE();
+    case 16:
+      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '/') ADVANCE(18);
+      if (lookahead == '>') ADVANCE(41);
+      if (lookahead == '{') ADVANCE(45);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(68);
-      if (lookahead != 0) ADVANCE(70);
-      END_STATE();
-    case 16:
-      if (lookahead == '-') ADVANCE(12);
+          lookahead == ' ') SKIP(16)
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '\'' &&
+          lookahead != '<' &&
+          lookahead != '=' &&
+          lookahead != '}') ADVANCE(109);
       END_STATE();
     case 17:
-      if (lookahead == '/') ADVANCE(19);
-      if (lookahead == '=') ADVANCE(50);
-      if (lookahead == '>') ADVANCE(42);
-      if (lookahead == '{') ADVANCE(46);
+      if (lookahead == '/') ADVANCE(18);
+      if (lookahead == '=') ADVANCE(49);
+      if (lookahead == '>') ADVANCE(41);
+      if (lookahead == '{') ADVANCE(45);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -697,265 +737,271 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '"' &&
           lookahead != '\'' &&
           lookahead != '<' &&
-          lookahead != '}') ADVANCE(97);
+          lookahead != '}') ADVANCE(109);
       END_STATE();
     case 18:
-      if (lookahead == '>') ADVANCE(62);
+      if (lookahead == '>') ADVANCE(44);
       END_STATE();
     case 19:
-      if (lookahead == '>') ADVANCE(45);
+      if (lookahead == '>') ADVANCE(61);
       END_STATE();
     case 20:
-      if (lookahead == '>') ADVANCE(71);
+      if (lookahead == '>') ADVANCE(70);
       END_STATE();
     case 21:
-      if (lookahead == '>') ADVANCE(73);
+      if (lookahead == '>') ADVANCE(72);
       END_STATE();
     case 22:
-      if (lookahead == 'C') ADVANCE(26);
+      if (lookahead == 'C') ADVANCE(27);
       END_STATE();
     case 23:
-      if (lookahead == 'E') ADVANCE(40);
+      if (lookahead == 'D') ADVANCE(25);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(23)
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(83);
       END_STATE();
     case 24:
-      if (lookahead == 'O') ADVANCE(22);
+      if (lookahead == 'E') ADVANCE(39);
       END_STATE();
     case 25:
-      if (lookahead == 'P') ADVANCE(23);
+      if (lookahead == 'O') ADVANCE(22);
       END_STATE();
     case 26:
-      if (lookahead == 'T') ADVANCE(27);
+      if (lookahead == 'P') ADVANCE(24);
       END_STATE();
     case 27:
-      if (lookahead == 'Y') ADVANCE(25);
+      if (lookahead == 'T') ADVANCE(28);
       END_STATE();
     case 28:
-      if (lookahead == 'd') ADVANCE(75);
+      if (lookahead == 'Y') ADVANCE(26);
       END_STATE();
     case 29:
-      if (lookahead == 'l') ADVANCE(41);
+      if (lookahead == 'h') ADVANCE(32);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(29)
       END_STATE();
     case 30:
-      if (lookahead == 'm') ADVANCE(29);
+      if (lookahead == 'l') ADVANCE(40);
       END_STATE();
     case 31:
-      if (lookahead == 'n') ADVANCE(28);
+      if (lookahead == 'm') ADVANCE(30);
       END_STATE();
     case 32:
-      if (lookahead == 'o') ADVANCE(77);
+      if (lookahead == 't') ADVANCE(31);
       END_STATE();
     case 33:
-      if (lookahead == 't') ADVANCE(30);
+      if (lookahead == '{') ADVANCE(45);
+      if (lookahead == '}') ADVANCE(46);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(47);
+      if (lookahead != 0) ADVANCE(48);
       END_STATE();
     case 34:
-      if (lookahead == '{') ADVANCE(46);
-      if (lookahead == '}') ADVANCE(47);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(48);
-      if (lookahead != 0) ADVANCE(49);
-      END_STATE();
-    case 35:
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
+          lookahead == ' ') ADVANCE(34);
       if (lookahead != 0 &&
           lookahead != '<' &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(98);
+          lookahead != '}') ADVANCE(110);
+      END_STATE();
+    case 35:
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(82);
       END_STATE();
     case 36:
+      if (eof) ADVANCE(37);
+      if (lookahead == '<') ADVANCE(42);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(36)
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(95);
-      END_STATE();
-    case 37:
-      if (eof) ADVANCE(38);
-      if (lookahead == '<') ADVANCE(43);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(37)
       if (lookahead != 0 &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(98);
+          lookahead != '}') ADVANCE(110);
       END_STATE();
-    case 38:
+    case 37:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 39:
+    case 38:
       ACCEPT_TOKEN(anon_sym_LT_BANG);
-      if (lookahead == '-') ADVANCE(11);
+      if (lookahead == '-') ADVANCE(10);
       END_STATE();
-    case 40:
+    case 39:
       ACCEPT_TOKEN(anon_sym_DOCTYPE);
       END_STATE();
-    case 41:
+    case 40:
       ACCEPT_TOKEN(anon_sym_html);
       END_STATE();
-    case 42:
+    case 41:
       ACCEPT_TOKEN(anon_sym_GT);
       END_STATE();
-    case 43:
+    case 42:
       ACCEPT_TOKEN(anon_sym_LT);
-      if (lookahead == '!') ADVANCE(39);
-      if (lookahead == '%') ADVANCE(58);
-      if (lookahead == '/') ADVANCE(44);
+      if (lookahead == '!') ADVANCE(38);
+      if (lookahead == '%') ADVANCE(57);
+      if (lookahead == '/') ADVANCE(43);
       END_STATE();
-    case 44:
+    case 43:
       ACCEPT_TOKEN(anon_sym_LT_SLASH);
       END_STATE();
-    case 45:
+    case 44:
       ACCEPT_TOKEN(anon_sym_SLASH_GT);
       END_STATE();
-    case 46:
+    case 45:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 47:
+    case 46:
       ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(aux_sym__expression_value_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(47);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(48);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(aux_sym__expression_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(48);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(anon_sym_EQ);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(sym_attribute_value);
+      if (!sym_attribute_value_character_set_1(lookahead)) ADVANCE(50);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(48);
+          lookahead == ' ') ADVANCE(52);
       if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(49);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(aux_sym__expression_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(49);
-      END_STATE();
-    case 50:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      END_STATE();
-    case 51:
-      ACCEPT_TOKEN(sym_attribute_value);
-      if (!sym_attribute_value_character_set_1(lookahead)) ADVANCE(51);
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+          lookahead != '\'') ADVANCE(53);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(53);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(53);
+          lookahead == ' ') ADVANCE(55);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(54);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token1);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(54);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+          lookahead != '"') ADVANCE(56);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(56);
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(57);
+          lookahead != '"') ADVANCE(56);
       END_STATE();
     case 57:
-      ACCEPT_TOKEN(aux_sym_quoted_attribute_value_token2);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(57);
+      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
+      if (lookahead == '!') ADVANCE(15);
+      if (lookahead == '#') ADVANCE(73);
+      if (lookahead == '%') ADVANCE(59);
+      if (lookahead == '=') ADVANCE(58);
       END_STATE();
     case 58:
-      ACCEPT_TOKEN(anon_sym_LT_PERCENT);
-      if (lookahead == '!') ADVANCE(16);
-      if (lookahead == '#') ADVANCE(74);
-      if (lookahead == '%') ADVANCE(60);
-      if (lookahead == '=') ADVANCE(59);
-      END_STATE();
-    case 59:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_EQ);
       END_STATE();
-    case 60:
+    case 59:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT);
-      if (lookahead == '=') ADVANCE(61);
+      if (lookahead == '=') ADVANCE(60);
       END_STATE();
-    case 61:
+    case 60:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_PERCENT_EQ);
       END_STATE();
-    case 62:
+    case 61:
       ACCEPT_TOKEN(anon_sym_PERCENT_GT);
       END_STATE();
-    case 63:
+    case 62:
       ACCEPT_TOKEN(anon_sym_LT_BANG_DASH_DASH);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(aux_sym__html_comment_token1);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(69);
+      if (lookahead == '-') ADVANCE(68);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(65);
-      if (lookahead != 0) ADVANCE(70);
+          lookahead == ' ') ADVANCE(64);
+      if (lookahead != 0) ADVANCE(69);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(aux_sym__html_comment_token1);
+      if (lookahead == '-') ADVANCE(8);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(7);
+      if (lookahead == '-') ADVANCE(63);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(66);
+      if (lookahead != 0) ADVANCE(69);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(64);
+      if (lookahead == '-') ADVANCE(65);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(67);
-      if (lookahead != 0) ADVANCE(70);
+      if (lookahead != 0) ADVANCE(69);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(66);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(68);
-      if (lookahead != 0) ADVANCE(70);
+      if (lookahead == '-') ADVANCE(20);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead == '-') ADVANCE(20);
+      if (lookahead != 0 &&
+          lookahead != '-') ADVANCE(69);
       END_STATE();
     case 70:
-      ACCEPT_TOKEN(aux_sym__html_comment_token1);
-      if (lookahead != 0 &&
-          lookahead != '-') ADVANCE(70);
-      END_STATE();
-    case 71:
       ACCEPT_TOKEN(anon_sym_DASH_DASH_GT);
       END_STATE();
-    case 72:
+    case 71:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_BANG_DASH_DASH);
       END_STATE();
-    case 73:
+    case 72:
       ACCEPT_TOKEN(anon_sym_DASH_DASH_PERCENT_GT);
       END_STATE();
-    case 74:
+    case 73:
       ACCEPT_TOKEN(anon_sym_LT_PERCENT_POUND);
+      END_STATE();
+    case 74:
+      ACCEPT_TOKEN(aux_sym_partial_expression_value_token1);
+      if (lookahead == '}') ADVANCE(75);
+      if (lookahead == ')' ||
+          lookahead == ']') ADVANCE(74);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym_partial_expression_value_token1);
@@ -973,7 +1019,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(anon_sym_do);
@@ -985,82 +1031,91 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
     case 79:
-      ACCEPT_TOKEN(anon_sym_DASH_GT);
-      END_STATE();
-    case 80:
       ACCEPT_TOKEN(anon_sym_DASH_GT);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
-    case 81:
+    case 80:
       ACCEPT_TOKEN(anon_sym_POUND);
       END_STATE();
+    case 81:
+      ACCEPT_TOKEN(anon_sym_DOT);
+      END_STATE();
     case 82:
-      ACCEPT_TOKEN(sym__code);
+      ACCEPT_TOKEN(sym_module);
+      if (lookahead == '.') ADVANCE(35);
+      if (!sym_module_character_set_1(lookahead)) ADVANCE(82);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(82);
-      if (lookahead == '-') ADVANCE(88);
-      if (lookahead == 'd') ADVANCE(91);
-      if (lookahead == 'e') ADVANCE(90);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(83);
-      if (lookahead != 0) ADVANCE(92);
+      ACCEPT_TOKEN(sym_function);
+      if (!sym_module_character_set_1(lookahead)) ADVANCE(83);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(82);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(84);
-      if (lookahead != 0) ADVANCE(92);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(87);
-      if (lookahead == '-') ADVANCE(88);
-      if (lookahead == 'd') ADVANCE(91);
+      if (lookahead == '%') ADVANCE(84);
+      if (lookahead == '-') ADVANCE(89);
+      if (lookahead == 'd') ADVANCE(93);
+      if (lookahead == 'e') ADVANCE(92);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(85);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(94);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '%') ADVANCE(87);
+      if (lookahead == '%') ADVANCE(84);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') ADVANCE(86);
-      if (lookahead != 0) ADVANCE(92);
+      if (lookahead != 0) ADVANCE(94);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '>') ADVANCE(62);
+      if (lookahead == '%') ADVANCE(90);
+      if (lookahead == '-') ADVANCE(89);
+      if (lookahead == 'd') ADVANCE(93);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(87);
+      if (lookahead != 0) ADVANCE(94);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == '>') ADVANCE(80);
+      if (lookahead == '%') ADVANCE(90);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(88);
+      if (lookahead != 0) ADVANCE(94);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '>') ADVANCE(79);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
-    case 89:
+    case 90:
+      ACCEPT_TOKEN(sym__code);
+      if (lookahead == '>') ADVANCE(61);
+      END_STATE();
+    case 91:
       ACCEPT_TOKEN(sym__code);
       if (lookahead == 'd') ADVANCE(76);
       if (lookahead != 0 &&
@@ -1068,19 +1123,19 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
-    case 90:
+    case 92:
       ACCEPT_TOKEN(sym__code);
-      if (lookahead == 'n') ADVANCE(89);
+      if (lookahead == 'n') ADVANCE(91);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
-    case 91:
+    case 93:
       ACCEPT_TOKEN(sym__code);
       if (lookahead == 'o') ADVANCE(78);
       if (lookahead != 0 &&
@@ -1088,51 +1143,101 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
-    case 92:
+    case 94:
       ACCEPT_TOKEN(sym__code);
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
           lookahead != ' ' &&
-          lookahead != '%') ADVANCE(92);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(94);
-      END_STATE();
-    case 94:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(94);
+          lookahead != '%') ADVANCE(94);
       END_STATE();
     case 95:
-      ACCEPT_TOKEN(sym_component_name);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(95);
-      if (!sym_component_name_character_set_1(lookahead)) ADVANCE(96);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
+      if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(96);
       END_STATE();
     case 96:
-      ACCEPT_TOKEN(sym_component_name);
+      ACCEPT_TOKEN(sym_tag_name);
       if (!sym_tag_name_character_set_1(lookahead)) ADVANCE(96);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_attribute_name);
-      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(97);
+      if (lookahead == 'C') ADVANCE(101);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
       END_STATE();
     case 98:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'E') ADVANCE(39);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'O') ADVANCE(97);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'P') ADVANCE(98);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'T') ADVANCE(102);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 102:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'Y') ADVANCE(100);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 103:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'd') ADVANCE(74);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'l') ADVANCE(40);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'm') ADVANCE(104);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'n') ADVANCE(103);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 'o') ADVANCE(77);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (lookahead == 't') ADVANCE(105);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 109:
+      ACCEPT_TOKEN(sym_attribute_name);
+      if (!sym_attribute_name_character_set_1(lookahead)) ADVANCE(109);
+      END_STATE();
+    case 110:
       ACCEPT_TOKEN(sym_text);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(35);
+          lookahead == ' ') ADVANCE(34);
       if (lookahead != 0 &&
           lookahead != '<' &&
           lookahead != '>' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(98);
+          lookahead != '}') ADVANCE(110);
       END_STATE();
     default:
       return false;
@@ -1141,93 +1246,98 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 37},
-  [2] = {.lex_state = 37},
-  [3] = {.lex_state = 37},
-  [4] = {.lex_state = 37},
-  [5] = {.lex_state = 37},
-  [6] = {.lex_state = 37},
-  [7] = {.lex_state = 37},
-  [8] = {.lex_state = 37},
-  [9] = {.lex_state = 37},
-  [10] = {.lex_state = 37},
-  [11] = {.lex_state = 37},
-  [12] = {.lex_state = 37},
-  [13] = {.lex_state = 37},
-  [14] = {.lex_state = 37},
-  [15] = {.lex_state = 37},
-  [16] = {.lex_state = 37},
-  [17] = {.lex_state = 37},
-  [18] = {.lex_state = 37},
-  [19] = {.lex_state = 37},
-  [20] = {.lex_state = 37},
-  [21] = {.lex_state = 37},
-  [22] = {.lex_state = 37},
-  [23] = {.lex_state = 37},
-  [24] = {.lex_state = 37},
-  [25] = {.lex_state = 37},
-  [26] = {.lex_state = 37},
-  [27] = {.lex_state = 37},
-  [28] = {.lex_state = 37},
-  [29] = {.lex_state = 37},
-  [30] = {.lex_state = 17},
+  [1] = {.lex_state = 36},
+  [2] = {.lex_state = 36},
+  [3] = {.lex_state = 36},
+  [4] = {.lex_state = 36},
+  [5] = {.lex_state = 36},
+  [6] = {.lex_state = 36},
+  [7] = {.lex_state = 36},
+  [8] = {.lex_state = 36},
+  [9] = {.lex_state = 36},
+  [10] = {.lex_state = 36},
+  [11] = {.lex_state = 36},
+  [12] = {.lex_state = 36},
+  [13] = {.lex_state = 36},
+  [14] = {.lex_state = 36},
+  [15] = {.lex_state = 36},
+  [16] = {.lex_state = 36},
+  [17] = {.lex_state = 36},
+  [18] = {.lex_state = 36},
+  [19] = {.lex_state = 36},
+  [20] = {.lex_state = 36},
+  [21] = {.lex_state = 36},
+  [22] = {.lex_state = 36},
+  [23] = {.lex_state = 36},
+  [24] = {.lex_state = 36},
+  [25] = {.lex_state = 36},
+  [26] = {.lex_state = 36},
+  [27] = {.lex_state = 36},
+  [28] = {.lex_state = 36},
+  [29] = {.lex_state = 36},
+  [30] = {.lex_state = 4},
   [31] = {.lex_state = 17},
-  [32] = {.lex_state = 3},
+  [32] = {.lex_state = 17},
   [33] = {.lex_state = 17},
   [34] = {.lex_state = 17},
   [35] = {.lex_state = 17},
   [36] = {.lex_state = 1},
-  [37] = {.lex_state = 34},
-  [38] = {.lex_state = 17},
-  [39] = {.lex_state = 5},
-  [40] = {.lex_state = 34},
-  [41] = {.lex_state = 5},
-  [42] = {.lex_state = 34},
-  [43] = {.lex_state = 17},
-  [44] = {.lex_state = 34},
-  [45] = {.lex_state = 17},
+  [37] = {.lex_state = 33},
+  [38] = {.lex_state = 16},
+  [39] = {.lex_state = 17},
+  [40] = {.lex_state = 33},
+  [41] = {.lex_state = 33},
+  [42] = {.lex_state = 6},
+  [43] = {.lex_state = 6},
+  [44] = {.lex_state = 17},
+  [45] = {.lex_state = 33},
   [46] = {.lex_state = 17},
   [47] = {.lex_state = 17},
-  [48] = {.lex_state = 34},
+  [48] = {.lex_state = 33},
   [49] = {.lex_state = 17},
-  [50] = {.lex_state = 13},
-  [51] = {.lex_state = 6},
-  [52] = {.lex_state = 15},
-  [53] = {.lex_state = 13},
-  [54] = {.lex_state = 6},
-  [55] = {.lex_state = 34},
-  [56] = {.lex_state = 6},
-  [57] = {.lex_state = 34},
-  [58] = {.lex_state = 6},
-  [59] = {.lex_state = 6},
-  [60] = {.lex_state = 34},
-  [61] = {.lex_state = 6},
-  [62] = {.lex_state = 6},
-  [63] = {.lex_state = 15},
-  [64] = {.lex_state = 6},
-  [65] = {.lex_state = 14},
-  [66] = {.lex_state = 4},
-  [67] = {.lex_state = 0},
-  [68] = {.lex_state = 36},
-  [69] = {.lex_state = 14},
-  [70] = {.lex_state = 0},
-  [71] = {.lex_state = 9},
-  [72] = {.lex_state = 2},
-  [73] = {.lex_state = 0},
-  [74] = {.lex_state = 0},
-  [75] = {.lex_state = 0},
-  [76] = {.lex_state = 36},
+  [50] = {.lex_state = 17},
+  [51] = {.lex_state = 17},
+  [52] = {.lex_state = 17},
+  [53] = {.lex_state = 3},
+  [54] = {.lex_state = 12},
+  [55] = {.lex_state = 33},
+  [56] = {.lex_state = 14},
+  [57] = {.lex_state = 12},
+  [58] = {.lex_state = 7},
+  [59] = {.lex_state = 7},
+  [60] = {.lex_state = 7},
+  [61] = {.lex_state = 7},
+  [62] = {.lex_state = 33},
+  [63] = {.lex_state = 33},
+  [64] = {.lex_state = 7},
+  [65] = {.lex_state = 3},
+  [66] = {.lex_state = 7},
+  [67] = {.lex_state = 7},
+  [68] = {.lex_state = 14},
+  [69] = {.lex_state = 7},
+  [70] = {.lex_state = 9},
+  [71] = {.lex_state = 13},
+  [72] = {.lex_state = 3},
+  [73] = {.lex_state = 13},
+  [74] = {.lex_state = 5},
+  [75] = {.lex_state = 3},
+  [76] = {.lex_state = 2},
   [77] = {.lex_state = 0},
-  [78] = {.lex_state = 0},
-  [79] = {.lex_state = 0},
+  [78] = {.lex_state = 23},
+  [79] = {.lex_state = 29},
   [80] = {.lex_state = 0},
-  [81] = {.lex_state = 0},
-  [82] = {.lex_state = 0},
-  [83] = {.lex_state = 0},
+  [81] = {.lex_state = 23},
+  [82] = {.lex_state = 3},
+  [83] = {.lex_state = 3},
   [84] = {.lex_state = 0},
   [85] = {.lex_state = 0},
-  [86] = {.lex_state = 36},
+  [86] = {.lex_state = 23},
   [87] = {.lex_state = 0},
+  [88] = {.lex_state = 0},
+  [89] = {.lex_state = 0},
+  [90] = {.lex_state = 0},
+  [91] = {.lex_state = 0},
+  [92] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1249,19 +1359,17 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LT_PERCENT_EQ] = ACTIONS(1),
     [anon_sym_LT_PERCENT_PERCENT] = ACTIONS(1),
     [anon_sym_LT_PERCENT_PERCENT_EQ] = ACTIONS(1),
-    [anon_sym_PERCENT_GT] = ACTIONS(1),
     [anon_sym_LT_BANG_DASH_DASH] = ACTIONS(1),
-    [anon_sym_DASH_DASH_GT] = ACTIONS(1),
     [anon_sym_LT_PERCENT_BANG_DASH_DASH] = ACTIONS(1),
-    [anon_sym_DASH_DASH_PERCENT_GT] = ACTIONS(1),
     [anon_sym_LT_PERCENT_POUND] = ACTIONS(1),
     [aux_sym_partial_expression_value_token1] = ACTIONS(1),
     [anon_sym_do] = ACTIONS(1),
-    [anon_sym_DASH_GT] = ACTIONS(1),
     [anon_sym_POUND] = ACTIONS(1),
+    [anon_sym_DOT] = ACTIONS(1),
+    [sym_attribute_name] = ACTIONS(1),
   },
   [1] = {
-    [sym_fragment] = STATE(75),
+    [sym_fragment] = STATE(80),
     [sym__node] = STATE(7),
     [sym_doctype] = STATE(7),
     [sym_tag] = STATE(7),
@@ -1269,7 +1377,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_start_tag] = STATE(6),
     [sym_self_closing_tag] = STATE(11),
     [sym_start_component] = STATE(2),
-    [sym_self_closing_component] = STATE(8),
+    [sym_self_closing_component] = STATE(12),
     [sym_directive] = STATE(7),
     [sym_comment] = STATE(7),
     [sym__html_comment] = STATE(13),
@@ -1310,11 +1418,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_start_component,
     STATE(6), 1,
       sym_start_tag,
-    STATE(8), 1,
-      sym_self_closing_component,
     STATE(11), 1,
       sym_self_closing_tag,
-    STATE(21), 1,
+    STATE(12), 1,
+      sym_self_closing_component,
+    STATE(19), 1,
       sym_end_component,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1353,11 +1461,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_start_component,
     STATE(6), 1,
       sym_start_tag,
-    STATE(8), 1,
-      sym_self_closing_component,
     STATE(11), 1,
       sym_self_closing_tag,
-    STATE(23), 1,
+    STATE(12), 1,
+      sym_self_closing_component,
+    STATE(24), 1,
       sym_end_tag,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1396,10 +1504,10 @@ static const uint16_t ts_small_parse_table[] = {
       sym_start_component,
     STATE(6), 1,
       sym_start_tag,
-    STATE(8), 1,
-      sym_self_closing_component,
     STATE(11), 1,
       sym_self_closing_tag,
+    STATE(12), 1,
+      sym_self_closing_component,
     STATE(14), 1,
       sym_end_component,
     ACTIONS(9), 2,
@@ -1437,10 +1545,10 @@ static const uint16_t ts_small_parse_table[] = {
       sym_start_component,
     STATE(6), 1,
       sym_start_tag,
-    STATE(8), 1,
-      sym_self_closing_component,
     STATE(11), 1,
       sym_self_closing_tag,
+    STATE(12), 1,
+      sym_self_closing_component,
     ACTIONS(29), 2,
       ts_builtin_sym_end,
       anon_sym_LT_SLASH,
@@ -1481,11 +1589,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_start_component,
     STATE(6), 1,
       sym_start_tag,
-    STATE(8), 1,
-      sym_self_closing_component,
     STATE(11), 1,
       sym_self_closing_tag,
     STATE(12), 1,
+      sym_self_closing_component,
+    STATE(23), 1,
       sym_end_tag,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
@@ -1524,10 +1632,10 @@ static const uint16_t ts_small_parse_table[] = {
       sym_start_component,
     STATE(6), 1,
       sym_start_tag,
-    STATE(8), 1,
-      sym_self_closing_component,
     STATE(11), 1,
       sym_self_closing_tag,
+    STATE(12), 1,
+      sym_self_closing_component,
     ACTIONS(9), 2,
       anon_sym_LT_PERCENT,
       anon_sym_LT_PERCENT_PERCENT,
@@ -1874,83 +1982,83 @@ static const uint16_t ts_small_parse_table[] = {
       sym_text,
   [719] = 5,
     ACTIONS(147), 1,
-      anon_sym_GT,
-    ACTIONS(149), 1,
-      anon_sym_SLASH_GT,
-    ACTIONS(151), 1,
-      anon_sym_LBRACE,
-    ACTIONS(153), 1,
-      sym_attribute_name,
-    STATE(31), 3,
-      sym_expression,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
-  [737] = 4,
-    ACTIONS(157), 1,
-      anon_sym_LBRACE,
-    ACTIONS(160), 1,
-      sym_attribute_name,
-    ACTIONS(155), 2,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-    STATE(31), 3,
-      sym_expression,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
-  [753] = 5,
-    ACTIONS(163), 1,
       aux_sym_partial_expression_value_token1,
-    ACTIONS(167), 1,
+    ACTIONS(151), 1,
       sym__code,
-    STATE(39), 1,
+    STATE(43), 1,
       aux_sym__hash_comment_repeat1,
-    ACTIONS(165), 2,
+    ACTIONS(149), 2,
       anon_sym_do,
       anon_sym_DASH_GT,
-    STATE(74), 2,
+    STATE(83), 2,
       sym_expression_value,
       sym_partial_expression_value,
-  [771] = 5,
-    ACTIONS(151), 1,
-      anon_sym_LBRACE,
+  [737] = 5,
     ACTIONS(153), 1,
+      anon_sym_GT,
+    ACTIONS(155), 1,
+      anon_sym_SLASH_GT,
+    ACTIONS(157), 1,
+      anon_sym_LBRACE,
+    ACTIONS(159), 1,
+      sym_attribute_name,
+    STATE(35), 3,
+      sym_expression,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [755] = 5,
+    ACTIONS(157), 1,
+      anon_sym_LBRACE,
+    ACTIONS(159), 1,
+      sym_attribute_name,
+    ACTIONS(161), 1,
+      anon_sym_GT,
+    ACTIONS(163), 1,
+      anon_sym_SLASH_GT,
+    STATE(31), 3,
+      sym_expression,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [773] = 5,
+    ACTIONS(157), 1,
+      anon_sym_LBRACE,
+    ACTIONS(159), 1,
+      sym_attribute_name,
+    ACTIONS(165), 1,
+      anon_sym_GT,
+    ACTIONS(167), 1,
+      anon_sym_SLASH_GT,
+    STATE(34), 3,
+      sym_expression,
+      sym_attribute,
+      aux_sym_start_tag_repeat1,
+  [791] = 5,
+    ACTIONS(157), 1,
+      anon_sym_LBRACE,
+    ACTIONS(159), 1,
       sym_attribute_name,
     ACTIONS(169), 1,
       anon_sym_GT,
     ACTIONS(171), 1,
       anon_sym_SLASH_GT,
-    STATE(31), 3,
+    STATE(35), 3,
       sym_expression,
       sym_attribute,
       aux_sym_start_tag_repeat1,
-  [789] = 5,
-    ACTIONS(151), 1,
-      anon_sym_LBRACE,
-    ACTIONS(153), 1,
-      sym_attribute_name,
-    ACTIONS(173), 1,
-      anon_sym_GT,
+  [809] = 4,
     ACTIONS(175), 1,
-      anon_sym_SLASH_GT,
-    STATE(33), 3,
-      sym_expression,
-      sym_attribute,
-      aux_sym_start_tag_repeat1,
-  [807] = 5,
-    ACTIONS(151), 1,
       anon_sym_LBRACE,
-    ACTIONS(153), 1,
+    ACTIONS(178), 1,
       sym_attribute_name,
-    ACTIONS(177), 1,
+    ACTIONS(173), 2,
       anon_sym_GT,
-    ACTIONS(179), 1,
       anon_sym_SLASH_GT,
-    STATE(30), 3,
+    STATE(35), 3,
       sym_expression,
       sym_attribute,
       aux_sym_start_tag_repeat1,
   [825] = 5,
-    ACTIONS(151), 1,
+    ACTIONS(157), 1,
       anon_sym_LBRACE,
     ACTIONS(181), 1,
       sym_attribute_value,
@@ -1958,7 +2066,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_SQUOTE,
     ACTIONS(185), 1,
       anon_sym_DQUOTE,
-    STATE(46), 2,
+    STATE(50), 2,
       sym_expression,
       sym_quoted_attribute_value,
   [842] = 5,
@@ -1968,293 +2076,328 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_RBRACE,
     ACTIONS(191), 1,
       aux_sym__expression_value_token1,
-    STATE(42), 1,
+    STATE(40), 1,
       aux_sym_expression_repeat1,
-    STATE(57), 1,
+    STATE(62), 1,
       sym__expression_value,
-  [858] = 2,
+  [858] = 3,
     ACTIONS(195), 1,
+      anon_sym_DOT,
+    ACTIONS(197), 1,
+      sym_attribute_name,
+    ACTIONS(193), 3,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+  [870] = 2,
+    ACTIONS(201), 1,
       anon_sym_EQ,
-    ACTIONS(193), 4,
+    ACTIONS(199), 4,
       anon_sym_GT,
       anon_sym_SLASH_GT,
       anon_sym_LBRACE,
       sym_attribute_name,
-  [868] = 4,
-    ACTIONS(197), 1,
-      anon_sym_PERCENT_GT,
-    ACTIONS(201), 1,
-      sym__code,
-    STATE(41), 1,
-      aux_sym__hash_comment_repeat1,
-    ACTIONS(199), 2,
-      anon_sym_do,
-      anon_sym_DASH_GT,
-  [882] = 5,
+  [880] = 5,
     ACTIONS(187), 1,
       anon_sym_LBRACE,
     ACTIONS(191), 1,
       aux_sym__expression_value_token1,
     ACTIONS(203), 1,
       anon_sym_RBRACE,
-    STATE(37), 1,
-      aux_sym_expression_repeat1,
-    STATE(57), 1,
-      sym__expression_value,
-  [898] = 3,
-    ACTIONS(207), 1,
-      sym__code,
     STATE(41), 1,
+      aux_sym_expression_repeat1,
+    STATE(62), 1,
+      sym__expression_value,
+  [896] = 5,
+    ACTIONS(205), 1,
+      anon_sym_LBRACE,
+    ACTIONS(208), 1,
+      anon_sym_RBRACE,
+    ACTIONS(210), 1,
+      aux_sym__expression_value_token1,
+    STATE(41), 1,
+      aux_sym_expression_repeat1,
+    STATE(62), 1,
+      sym__expression_value,
+  [912] = 3,
+    ACTIONS(215), 1,
+      sym__code,
+    STATE(42), 1,
       aux_sym__hash_comment_repeat1,
-    ACTIONS(205), 3,
+    ACTIONS(213), 3,
       anon_sym_PERCENT_GT,
       anon_sym_do,
       anon_sym_DASH_GT,
-  [910] = 5,
-    ACTIONS(210), 1,
-      anon_sym_LBRACE,
-    ACTIONS(213), 1,
-      anon_sym_RBRACE,
-    ACTIONS(215), 1,
-      aux_sym__expression_value_token1,
-    STATE(42), 1,
-      aux_sym_expression_repeat1,
-    STATE(57), 1,
-      sym__expression_value,
-  [926] = 1,
-    ACTIONS(218), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [933] = 4,
-    ACTIONS(220), 1,
-      anon_sym_LBRACE,
+  [924] = 4,
+    ACTIONS(218), 1,
+      anon_sym_PERCENT_GT,
     ACTIONS(222), 1,
+      sym__code,
+    STATE(42), 1,
+      aux_sym__hash_comment_repeat1,
+    ACTIONS(220), 2,
+      anon_sym_do,
+      anon_sym_DASH_GT,
+  [938] = 1,
+    ACTIONS(224), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [945] = 4,
+    ACTIONS(226), 1,
+      anon_sym_LBRACE,
+    ACTIONS(228), 1,
       anon_sym_RBRACE,
-    ACTIONS(224), 1,
+    ACTIONS(230), 1,
       aux_sym__expression_value_token1,
-    STATE(81), 1,
+    STATE(92), 1,
       sym__expression_value,
-  [946] = 1,
-    ACTIONS(226), 4,
+  [958] = 1,
+    ACTIONS(232), 4,
       anon_sym_GT,
       anon_sym_SLASH_GT,
       anon_sym_LBRACE,
       sym_attribute_name,
-  [953] = 1,
-    ACTIONS(228), 4,
+  [965] = 1,
+    ACTIONS(234), 4,
       anon_sym_GT,
       anon_sym_SLASH_GT,
       anon_sym_LBRACE,
       sym_attribute_name,
-  [960] = 1,
-    ACTIONS(230), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
+  [972] = 4,
+    ACTIONS(226), 1,
       anon_sym_LBRACE,
-      sym_attribute_name,
-  [967] = 4,
-    ACTIONS(220), 1,
-      anon_sym_LBRACE,
-    ACTIONS(232), 1,
+    ACTIONS(236), 1,
       anon_sym_RBRACE,
-    ACTIONS(234), 1,
-      aux_sym__expression_value_token1,
-    STATE(87), 1,
-      sym__expression_value,
-  [980] = 1,
-    ACTIONS(236), 4,
-      anon_sym_GT,
-      anon_sym_SLASH_GT,
-      anon_sym_LBRACE,
-      sym_attribute_name,
-  [987] = 3,
     ACTIONS(238), 1,
-      aux_sym__html_comment_token1,
-    ACTIONS(240), 1,
-      anon_sym_DASH_DASH_GT,
-    STATE(53), 1,
-      aux_sym__html_comment_repeat1,
-  [997] = 3,
-    ACTIONS(242), 1,
-      anon_sym_PERCENT_GT,
-    ACTIONS(244), 1,
-      sym__code,
-    STATE(54), 1,
-      aux_sym__hash_comment_repeat1,
-  [1007] = 3,
-    ACTIONS(246), 1,
-      aux_sym__html_comment_token1,
-    ACTIONS(249), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(52), 1,
-      aux_sym__html_comment_repeat1,
-  [1017] = 3,
-    ACTIONS(249), 1,
-      anon_sym_DASH_DASH_GT,
-    ACTIONS(251), 1,
-      aux_sym__html_comment_token1,
-    STATE(53), 1,
-      aux_sym__html_comment_repeat1,
-  [1027] = 3,
-    ACTIONS(205), 1,
-      anon_sym_PERCENT_GT,
+      aux_sym__expression_value_token1,
+    STATE(77), 1,
+      sym__expression_value,
+  [985] = 1,
+    ACTIONS(240), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [992] = 1,
+    ACTIONS(242), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [999] = 1,
+    ACTIONS(244), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [1006] = 1,
+    ACTIONS(246), 4,
+      anon_sym_GT,
+      anon_sym_SLASH_GT,
+      anon_sym_LBRACE,
+      sym_attribute_name,
+  [1013] = 4,
+    ACTIONS(248), 1,
+      anon_sym_DOT,
+    ACTIONS(250), 1,
+      sym_module,
+    ACTIONS(252), 1,
+      sym_tag_name,
+    STATE(32), 1,
+      sym_component_name,
+  [1026] = 3,
     ACTIONS(254), 1,
-      sym__code,
-    STATE(54), 1,
-      aux_sym__hash_comment_repeat1,
-  [1037] = 2,
-    ACTIONS(259), 1,
+      aux_sym__html_comment_token1,
+    ACTIONS(256), 1,
+      anon_sym_DASH_DASH_GT,
+    STATE(57), 1,
+      aux_sym__html_comment_repeat1,
+  [1036] = 2,
+    ACTIONS(260), 1,
       aux_sym__expression_value_token1,
-    ACTIONS(257), 2,
+    ACTIONS(258), 2,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
-  [1045] = 3,
-    ACTIONS(261), 1,
-      anon_sym_PERCENT_GT,
-    ACTIONS(263), 1,
-      sym__code,
-    STATE(51), 1,
-      aux_sym__hash_comment_repeat1,
-  [1055] = 2,
+  [1044] = 3,
+    ACTIONS(262), 1,
+      aux_sym__html_comment_token1,
+    ACTIONS(265), 1,
+      anon_sym_DASH_DASH_PERCENT_GT,
+    STATE(56), 1,
+      aux_sym__html_comment_repeat1,
+  [1054] = 3,
+    ACTIONS(265), 1,
+      anon_sym_DASH_DASH_GT,
     ACTIONS(267), 1,
-      aux_sym__expression_value_token1,
-    ACTIONS(265), 2,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-  [1063] = 3,
-    ACTIONS(244), 1,
-      sym__code,
-    ACTIONS(261), 1,
+      aux_sym__html_comment_token1,
+    STATE(57), 1,
+      aux_sym__html_comment_repeat1,
+  [1064] = 3,
+    ACTIONS(213), 1,
       anon_sym_PERCENT_GT,
-    STATE(54), 1,
-      aux_sym__hash_comment_repeat1,
-  [1073] = 3,
-    ACTIONS(244), 1,
-      sym__code,
-    ACTIONS(269), 1,
-      anon_sym_PERCENT_GT,
-    STATE(54), 1,
-      aux_sym__hash_comment_repeat1,
-  [1083] = 2,
-    ACTIONS(273), 1,
-      aux_sym__expression_value_token1,
-    ACTIONS(271), 2,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-  [1091] = 3,
-    ACTIONS(275), 1,
-      anon_sym_PERCENT_GT,
-    ACTIONS(277), 1,
+    ACTIONS(270), 1,
       sym__code,
     STATE(58), 1,
       aux_sym__hash_comment_repeat1,
-  [1101] = 3,
-    ACTIONS(244), 1,
+  [1074] = 3,
+    ACTIONS(273), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(275), 1,
       sym__code,
-    ACTIONS(279), 1,
-      anon_sym_PERCENT_GT,
-    STATE(54), 1,
+    STATE(58), 1,
       aux_sym__hash_comment_repeat1,
-  [1111] = 3,
-    ACTIONS(281), 1,
-      aux_sym__html_comment_token1,
-    ACTIONS(283), 1,
-      anon_sym_DASH_DASH_PERCENT_GT,
-    STATE(52), 1,
-      aux_sym__html_comment_repeat1,
-  [1121] = 3,
-    ACTIONS(242), 1,
+  [1084] = 3,
+    ACTIONS(277), 1,
       anon_sym_PERCENT_GT,
-    ACTIONS(285), 1,
+    ACTIONS(279), 1,
+      sym__code,
+    STATE(69), 1,
+      aux_sym__hash_comment_repeat1,
+  [1094] = 3,
+    ACTIONS(275), 1,
+      sym__code,
+    ACTIONS(277), 1,
+      anon_sym_PERCENT_GT,
+    STATE(58), 1,
+      aux_sym__hash_comment_repeat1,
+  [1104] = 2,
+    ACTIONS(283), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(281), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [1112] = 2,
+    ACTIONS(287), 1,
+      aux_sym__expression_value_token1,
+    ACTIONS(285), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [1120] = 3,
+    ACTIONS(289), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(291), 1,
+      sym__code,
+    STATE(61), 1,
+      aux_sym__hash_comment_repeat1,
+  [1130] = 3,
+    ACTIONS(248), 1,
+      anon_sym_DOT,
+    ACTIONS(250), 1,
+      sym_module,
+    STATE(88), 1,
+      sym_component_name,
+  [1140] = 3,
+    ACTIONS(293), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(295), 1,
       sym__code,
     STATE(59), 1,
       aux_sym__hash_comment_repeat1,
-  [1131] = 2,
-    ACTIONS(287), 1,
-      aux_sym__html_comment_token1,
-    STATE(63), 1,
-      aux_sym__html_comment_repeat1,
-  [1138] = 2,
-    ACTIONS(289), 1,
+  [1150] = 3,
+    ACTIONS(275), 1,
       sym__code,
-    STATE(62), 1,
-      aux_sym__hash_comment_repeat1,
-  [1145] = 2,
-    ACTIONS(291), 1,
-      anon_sym_PERCENT_GT,
-    ACTIONS(293), 1,
-      anon_sym_POUND,
-  [1152] = 2,
-    ACTIONS(295), 1,
-      sym_tag_name,
     ACTIONS(297), 1,
-      sym_component_name,
-  [1159] = 2,
+      anon_sym_PERCENT_GT,
+    STATE(58), 1,
+      aux_sym__hash_comment_repeat1,
+  [1160] = 3,
     ACTIONS(299), 1,
       aux_sym__html_comment_token1,
-    STATE(50), 1,
-      aux_sym__html_comment_repeat1,
-  [1166] = 2,
     ACTIONS(301), 1,
+      anon_sym_DASH_DASH_PERCENT_GT,
+    STATE(56), 1,
+      aux_sym__html_comment_repeat1,
+  [1170] = 3,
+    ACTIONS(275), 1,
+      sym__code,
+    ACTIONS(293), 1,
       anon_sym_PERCENT_GT,
-    ACTIONS(303), 1,
-      anon_sym_POUND,
-  [1173] = 2,
-    ACTIONS(305), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(307), 1,
-      aux_sym_quoted_attribute_value_token1,
+    STATE(58), 1,
+      aux_sym__hash_comment_repeat1,
   [1180] = 2,
-    ACTIONS(305), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(309), 1,
-      aux_sym_quoted_attribute_value_token2,
-  [1187] = 1,
-    ACTIONS(311), 1,
-      anon_sym_html,
-  [1191] = 1,
-    ACTIONS(313), 1,
-      anon_sym_PERCENT_GT,
-  [1195] = 1,
-    ACTIONS(315), 1,
-      ts_builtin_sym_end,
-  [1199] = 1,
-    ACTIONS(317), 1,
-      sym_component_name,
-  [1203] = 1,
-    ACTIONS(319), 1,
-      anon_sym_GT,
-  [1207] = 1,
-    ACTIONS(321), 1,
-      anon_sym_GT,
-  [1211] = 1,
-    ACTIONS(323), 1,
+    ACTIONS(303), 1,
       anon_sym_SQUOTE,
-  [1215] = 1,
-    ACTIONS(323), 1,
+    ACTIONS(305), 1,
+      aux_sym_quoted_attribute_value_token1,
+  [1187] = 2,
+    ACTIONS(307), 1,
+      aux_sym__html_comment_token1,
+    STATE(54), 1,
+      aux_sym__html_comment_repeat1,
+  [1194] = 2,
+    ACTIONS(309), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(311), 1,
+      anon_sym_POUND,
+  [1201] = 2,
+    ACTIONS(313), 1,
+      aux_sym__html_comment_token1,
+    STATE(68), 1,
+      aux_sym__html_comment_repeat1,
+  [1208] = 2,
+    ACTIONS(315), 1,
+      sym__code,
+    STATE(67), 1,
+      aux_sym__hash_comment_repeat1,
+  [1215] = 2,
+    ACTIONS(317), 1,
+      anon_sym_PERCENT_GT,
+    ACTIONS(319), 1,
+      anon_sym_POUND,
+  [1222] = 2,
+    ACTIONS(303), 1,
       anon_sym_DQUOTE,
-  [1219] = 1,
+    ACTIONS(321), 1,
+      aux_sym_quoted_attribute_value_token2,
+  [1229] = 1,
+    ACTIONS(323), 1,
+      anon_sym_RBRACE,
+  [1233] = 1,
     ACTIONS(325), 1,
-      anon_sym_RBRACE,
-  [1223] = 1,
+      sym_function,
+  [1237] = 1,
     ACTIONS(327), 1,
-      anon_sym_DOCTYPE,
-  [1227] = 1,
+      anon_sym_html,
+  [1241] = 1,
     ACTIONS(329), 1,
-      anon_sym_GT,
-  [1231] = 1,
-    ACTIONS(273), 1,
-      anon_sym_RBRACE,
-  [1235] = 1,
-    ACTIONS(259), 1,
-      anon_sym_RBRACE,
-  [1239] = 1,
+      ts_builtin_sym_end,
+  [1245] = 1,
     ACTIONS(331), 1,
-      sym_tag_name,
-  [1243] = 1,
+      anon_sym_DOCTYPE,
+  [1249] = 1,
     ACTIONS(333), 1,
+      sym_tag_name,
+  [1253] = 1,
+    ACTIONS(335), 1,
+      anon_sym_PERCENT_GT,
+  [1257] = 1,
+    ACTIONS(337), 1,
+      anon_sym_SQUOTE,
+  [1261] = 1,
+    ACTIONS(337), 1,
+      anon_sym_DQUOTE,
+  [1265] = 1,
+    ACTIONS(339), 1,
+      sym_function,
+  [1269] = 1,
+    ACTIONS(341), 1,
+      anon_sym_GT,
+  [1273] = 1,
+    ACTIONS(343), 1,
+      anon_sym_GT,
+  [1277] = 1,
+    ACTIONS(287), 1,
+      anon_sym_RBRACE,
+  [1281] = 1,
+    ACTIONS(260), 1,
+      anon_sym_RBRACE,
+  [1285] = 1,
+    ACTIONS(345), 1,
+      anon_sym_GT,
+  [1289] = 1,
+    ACTIONS(347), 1,
       anon_sym_RBRACE,
 };
 
@@ -2289,225 +2432,237 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(29)] = 703,
   [SMALL_STATE(30)] = 719,
   [SMALL_STATE(31)] = 737,
-  [SMALL_STATE(32)] = 753,
-  [SMALL_STATE(33)] = 771,
-  [SMALL_STATE(34)] = 789,
-  [SMALL_STATE(35)] = 807,
+  [SMALL_STATE(32)] = 755,
+  [SMALL_STATE(33)] = 773,
+  [SMALL_STATE(34)] = 791,
+  [SMALL_STATE(35)] = 809,
   [SMALL_STATE(36)] = 825,
   [SMALL_STATE(37)] = 842,
   [SMALL_STATE(38)] = 858,
-  [SMALL_STATE(39)] = 868,
-  [SMALL_STATE(40)] = 882,
-  [SMALL_STATE(41)] = 898,
-  [SMALL_STATE(42)] = 910,
-  [SMALL_STATE(43)] = 926,
-  [SMALL_STATE(44)] = 933,
-  [SMALL_STATE(45)] = 946,
-  [SMALL_STATE(46)] = 953,
-  [SMALL_STATE(47)] = 960,
-  [SMALL_STATE(48)] = 967,
-  [SMALL_STATE(49)] = 980,
-  [SMALL_STATE(50)] = 987,
-  [SMALL_STATE(51)] = 997,
-  [SMALL_STATE(52)] = 1007,
-  [SMALL_STATE(53)] = 1017,
-  [SMALL_STATE(54)] = 1027,
-  [SMALL_STATE(55)] = 1037,
-  [SMALL_STATE(56)] = 1045,
-  [SMALL_STATE(57)] = 1055,
-  [SMALL_STATE(58)] = 1063,
-  [SMALL_STATE(59)] = 1073,
-  [SMALL_STATE(60)] = 1083,
-  [SMALL_STATE(61)] = 1091,
-  [SMALL_STATE(62)] = 1101,
-  [SMALL_STATE(63)] = 1111,
-  [SMALL_STATE(64)] = 1121,
-  [SMALL_STATE(65)] = 1131,
-  [SMALL_STATE(66)] = 1138,
-  [SMALL_STATE(67)] = 1145,
-  [SMALL_STATE(68)] = 1152,
-  [SMALL_STATE(69)] = 1159,
-  [SMALL_STATE(70)] = 1166,
-  [SMALL_STATE(71)] = 1173,
-  [SMALL_STATE(72)] = 1180,
-  [SMALL_STATE(73)] = 1187,
-  [SMALL_STATE(74)] = 1191,
-  [SMALL_STATE(75)] = 1195,
-  [SMALL_STATE(76)] = 1199,
-  [SMALL_STATE(77)] = 1203,
-  [SMALL_STATE(78)] = 1207,
-  [SMALL_STATE(79)] = 1211,
-  [SMALL_STATE(80)] = 1215,
-  [SMALL_STATE(81)] = 1219,
-  [SMALL_STATE(82)] = 1223,
-  [SMALL_STATE(83)] = 1227,
-  [SMALL_STATE(84)] = 1231,
-  [SMALL_STATE(85)] = 1235,
-  [SMALL_STATE(86)] = 1239,
-  [SMALL_STATE(87)] = 1243,
+  [SMALL_STATE(39)] = 870,
+  [SMALL_STATE(40)] = 880,
+  [SMALL_STATE(41)] = 896,
+  [SMALL_STATE(42)] = 912,
+  [SMALL_STATE(43)] = 924,
+  [SMALL_STATE(44)] = 938,
+  [SMALL_STATE(45)] = 945,
+  [SMALL_STATE(46)] = 958,
+  [SMALL_STATE(47)] = 965,
+  [SMALL_STATE(48)] = 972,
+  [SMALL_STATE(49)] = 985,
+  [SMALL_STATE(50)] = 992,
+  [SMALL_STATE(51)] = 999,
+  [SMALL_STATE(52)] = 1006,
+  [SMALL_STATE(53)] = 1013,
+  [SMALL_STATE(54)] = 1026,
+  [SMALL_STATE(55)] = 1036,
+  [SMALL_STATE(56)] = 1044,
+  [SMALL_STATE(57)] = 1054,
+  [SMALL_STATE(58)] = 1064,
+  [SMALL_STATE(59)] = 1074,
+  [SMALL_STATE(60)] = 1084,
+  [SMALL_STATE(61)] = 1094,
+  [SMALL_STATE(62)] = 1104,
+  [SMALL_STATE(63)] = 1112,
+  [SMALL_STATE(64)] = 1120,
+  [SMALL_STATE(65)] = 1130,
+  [SMALL_STATE(66)] = 1140,
+  [SMALL_STATE(67)] = 1150,
+  [SMALL_STATE(68)] = 1160,
+  [SMALL_STATE(69)] = 1170,
+  [SMALL_STATE(70)] = 1180,
+  [SMALL_STATE(71)] = 1187,
+  [SMALL_STATE(72)] = 1194,
+  [SMALL_STATE(73)] = 1201,
+  [SMALL_STATE(74)] = 1208,
+  [SMALL_STATE(75)] = 1215,
+  [SMALL_STATE(76)] = 1222,
+  [SMALL_STATE(77)] = 1229,
+  [SMALL_STATE(78)] = 1233,
+  [SMALL_STATE(79)] = 1237,
+  [SMALL_STATE(80)] = 1241,
+  [SMALL_STATE(81)] = 1245,
+  [SMALL_STATE(82)] = 1249,
+  [SMALL_STATE(83)] = 1253,
+  [SMALL_STATE(84)] = 1257,
+  [SMALL_STATE(85)] = 1261,
+  [SMALL_STATE(86)] = 1265,
+  [SMALL_STATE(87)] = 1269,
+  [SMALL_STATE(88)] = 1273,
+  [SMALL_STATE(89)] = 1277,
+  [SMALL_STATE(90)] = 1281,
+  [SMALL_STATE(91)] = 1285,
+  [SMALL_STATE(92)] = 1289,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
   [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
   [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
   [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
   [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2),
-  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(82),
-  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(68),
-  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(32),
-  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(32),
-  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(69),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(65),
-  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(66),
+  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(81),
+  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(53),
+  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(30),
+  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(30),
+  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(71),
+  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(73),
+  [49] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(74),
   [52] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_fragment_repeat1, 2), SHIFT_REPEAT(5),
   [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
   [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_fragment, 1),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 1),
-  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 1),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__html_comment, 3),
+  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__html_comment, 3),
   [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_directive, 3),
   [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_directive, 3),
   [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 3),
   [69] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 3),
   [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 1),
   [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 1),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
-  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 1),
+  [77] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 1),
   [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 1),
   [81] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 1),
   [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 3),
   [85] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 3),
-  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_component, 3),
-  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_component, 3),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3),
-  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__html_comment, 3),
-  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__html_comment, 3),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3),
-  [101] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_tag, 3),
-  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 4),
-  [105] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 4),
-  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 3),
-  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 3),
-  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 2),
-  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 2),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 3),
+  [89] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 3),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_component, 3),
+  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_component, 3),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4),
+  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__bang_comment, 3),
+  [101] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__bang_comment, 3),
+  [103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component, 2),
+  [105] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component, 2),
+  [107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_end_tag, 3),
+  [109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_end_tag, 3),
+  [111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_component, 4),
+  [113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_component, 4),
   [115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__hash_comment, 3),
   [117] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__hash_comment, 3),
-  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
-  [121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_self_closing_tag, 4),
-  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_self_closing_tag, 4),
+  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
+  [121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
+  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
   [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctype, 4),
   [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctype, 4),
   [131] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 4),
   [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 4),
-  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 4),
-  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 4),
-  [139] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 3),
-  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 3),
+  [135] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_tag, 3),
+  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_tag, 3),
+  [139] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 4),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 4),
   [143] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_start_component, 3),
   [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_start_component, 3),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2),
-  [157] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(40),
-  [160] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(38),
-  [163] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [165] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
-  [167] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
-  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 1),
-  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression_value, 1),
-  [199] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [201] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [205] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2),
-  [207] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2), SHIFT_REPEAT(41),
-  [210] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(44),
-  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2),
-  [215] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(57),
-  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 2),
-  [220] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [222] = {.entry = {.count = 1, .reusable = false}}, SHIFT(60),
-  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3, .production_id = 1),
-  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3),
-  [230] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2),
-  [232] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
-  [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3),
-  [238] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
-  [240] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [242] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 3),
-  [244] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
-  [246] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(52),
-  [249] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2),
-  [251] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(53),
-  [254] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2), SHIFT_REPEAT(54),
-  [257] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 3),
-  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 3),
-  [261] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 2),
-  [263] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [265] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 1),
-  [267] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 1),
-  [269] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 4),
-  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 2),
-  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 2),
-  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 1),
-  [277] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [279] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
-  [283] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [285] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
-  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
-  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [291] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression_value, 1),
-  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression_value, 2),
-  [303] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [305] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
-  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [309] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [311] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [315] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [317] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [319] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [329] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [147] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
+  [149] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
+  [151] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2),
+  [175] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(37),
+  [178] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_start_tag_repeat1, 2), SHIFT_REPEAT(39),
+  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [187] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [189] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
+  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component_name, 1),
+  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [197] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_component_name, 1),
+  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 1),
+  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(47),
+  [205] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(48),
+  [208] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 2),
+  [210] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 2), SHIFT_REPEAT(62),
+  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2),
+  [215] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2), SHIFT_REPEAT(42),
+  [218] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_expression_value, 1),
+  [220] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [222] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [224] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 2),
+  [226] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [228] = {.entry = {.count = 1, .reusable = false}}, SHIFT(89),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component_name, 2),
+  [234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3, .production_id = 1),
+  [236] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [240] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_component_name, 3),
+  [242] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3),
+  [244] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 2),
+  [246] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_quoted_attribute_value, 3),
+  [248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [254] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
+  [256] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [258] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 3),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 3),
+  [262] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(56),
+  [265] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2),
+  [267] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__html_comment_repeat1, 2), SHIFT_REPEAT(57),
+  [270] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__hash_comment_repeat1, 2), SHIFT_REPEAT(58),
+  [273] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 4),
+  [275] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [277] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 2),
+  [279] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
+  [281] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_expression_repeat1, 1),
+  [283] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_expression_repeat1, 1),
+  [285] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression_value, 2),
+  [287] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression_value, 2),
+  [289] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 1),
+  [291] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
+  [293] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_partial_expression_value, 3),
+  [295] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
+  [297] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [299] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [301] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [303] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
+  [305] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [309] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression_value, 1),
+  [311] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [317] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_partial_expression_value, 2),
+  [319] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [325] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [329] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [335] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [341] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [343] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [345] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [347] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -9,7 +9,9 @@ Unquoted Attribute
 (fragment
   (component
     (self_closing_component
-      (component_name)
+      (component_name
+        (module)
+        (function))
       (attribute
         (attribute_name)
         (attribute_value)))))
@@ -25,7 +27,9 @@ Boolean Attribute
 (fragment
   (component
     (self_closing_component
-      (component_name)
+      (component_name
+        (module)
+        (function))
       (attribute
         (attribute_name)))))
 
@@ -40,7 +44,9 @@ Single-Quoted Attribute
 (fragment
   (component
     (self_closing_component
-      (component_name)
+      (component_name
+        (module)
+        (function))
       (attribute
         (attribute_name)
         (quoted_attribute_value
@@ -57,7 +63,9 @@ Double-Quoted Attribute
 (fragment
   (component
     (self_closing_component
-      (component_name)
+      (component_name
+        (module)
+        (function))
       (attribute
         (attribute_name)
         (quoted_attribute_value
@@ -74,7 +82,9 @@ Expression Attribute
 (fragment
   (component
     (self_closing_component
-      (component_name)
+      (component_name
+        (module)
+        (function))
       (attribute
         (attribute_name)
         (expression

--- a/test/corpus/components.txt
+++ b/test/corpus/components.txt
@@ -10,22 +10,28 @@ Component
 (fragment
   (component
     (start_component
-      (component_name))
+      (component_name
+        (module)
+        (function)))
     (end_component
-      (component_name))))
+      (component_name
+        (module)
+        (function)))))
 
 ================================================================================
 Self-Closing Component
 ================================================================================
 
-<Root.render/>
+<MyApp.Components.Root.render/>
 
 --------------------------------------------------------------------------------
 
 (fragment
   (component
     (self_closing_component
-      (component_name))))
+      (component_name
+        (module)
+        (function)))))
 
 ================================================================================
 Nested Components
@@ -42,17 +48,24 @@ Nested Components
 (fragment
   (component
     (start_component
-      (component_name))
+      (component_name
+        (module)
+        (function)))
     (component
       (start_component
-        (component_name))
+        (component_name
+          (module)))
       (component
         (self_closing_component
-          (component_name)))
+          (component_name
+            (module))))
       (end_component
-        (component_name)))
+        (component_name
+          (module))))
     (end_component
-      (component_name))))
+      (component_name
+        (module)
+        (function)))))
 
 ================================================================================
 Function with Module Remote Component
@@ -65,7 +78,9 @@ Function with Module Remote Component
 (fragment
   (component
     (self_closing_component
-      (component_name)
+      (component_name
+        (module)
+        (function))
       (attribute
         (attribute_name)
         (quoted_attribute_value
@@ -82,7 +97,8 @@ Function without Remote Component
 (fragment
   (component
     (self_closing_component
-      (component_name)
+      (component_name
+        (function))
       (attribute
         (attribute_name)
         (quoted_attribute_value
@@ -113,7 +129,9 @@ Simple Example
           (attribute_value))))
     (component
       (self_closing_component
-        (component_name)
+        (component_name
+          (module)
+          (function))
         (attribute
           (attribute_name)
           (quoted_attribute_value
@@ -126,7 +144,8 @@ Simple Example
           (expression_value))))
     (component
       (self_closing_component
-        (component_name)
+        (component_name
+          (function))
         (attribute
           (attribute_name)
           (quoted_attribute_value

--- a/test/corpus/directives.txt
+++ b/test/corpus/directives.txt
@@ -1,0 +1,42 @@
+================================================================================
+If expression spread between multiple directives
+================================================================================
+
+<%= if true do %>
+  <%= @x %>
+<% end %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (partial_expression_value))
+  (directive
+    (expression_value))
+  (directive
+    (partial_expression_value)))
+
+================================================================================
+Case expression spread between multiple directives
+================================================================================
+
+<%= case @x do %>
+  <%= ^x -> %>X, <%= x %>
+  <%= _ -> %>Not X
+<% end %>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (directive
+    (partial_expression_value))
+  (directive
+    (partial_expression_value))
+  (text)
+  (directive
+    (expression_value))
+  (directive
+    (partial_expression_value))
+  (text)
+  (directive
+    (partial_expression_value)))

--- a/test/highlight/main.heex
+++ b/test/highlight/main.heex
@@ -22,19 +22,24 @@
     <%= if true do %>
     <%# <- keyword %>
     <%#            ^ keyword %>
-      <MyComponents.modal key=value key="value" key={ @value } />
+      <MyApp.Components.modal key=value key="value" key={ @value } />
       <%# <- punctuation.bracket %>
       <%# ^ module %>
-      <%#                  ^ attribute %>
-      <%#                      ^ string %>
-      <%#                            ^ attribute %>
-      <%#                                 ^ string %>
-      <%#                                        ^ attribute %>
-      <%#                                           ^ keyword %>
-      <%#                                                    ^ keyword %>
-      <%#                                                      ^ punctuation.bracket %>
+      <%#   ^ module %>
+      <%#       ^ module %>
+      <%#              ^ punctuation.delimiter %>
+      <%#                 ^ function %>
+      <%#                      ^ attribute %>
+      <%#                         ^ string %>
+      <%#                                ^ attribute %>
+      <%#                                    ^ string %>
+      <%#                                           ^ attribute %>
+      <%#                                               ^ keyword %>
+      <%#                                                        ^ keyword %>
+      <%#                                                          ^ punctuation.bracket %>
       <.form />
-      <%# ^ module %>
+      <%# ^ function %>
+<%#    ^ punctuation.delimiter %>
     <% end %>
     <%# here we're intentionally leaving a tag unclosed to trigger the error later on </html>: %>
     <div></div></div>

--- a/test/highlight/main.heex
+++ b/test/highlight/main.heex
@@ -11,7 +11,7 @@
     <link phx-track-static rel="stylesheet" src={ Routes.static_path(@conn, "/css/app.css") } />
     <%# <- punctuation.bracket %>
     <%# ^ tag %>
-    <%#    ^ attribute %>
+    <%#    ^ keyword %>
     <%#                     ^ attribute %>
     <%#                           ^ string %>
     <%#                                         ^ keyword %>

--- a/test/highlight/main.heex
+++ b/test/highlight/main.heex
@@ -28,7 +28,8 @@
       <%#   ^ module %>
       <%#       ^ module %>
       <%#              ^ punctuation.delimiter %>
-      <%#                 ^ function %>
+      <%#               ^ function %>
+      <%#                   ^ function %>
       <%#                      ^ attribute %>
       <%#                         ^ string %>
       <%#                                ^ attribute %>
@@ -40,6 +41,16 @@
       <.form />
       <%# ^ function %>
 <%#    ^ punctuation.delimiter %>
+      <Foo.Bar.Baz.Fizz.buzz />
+      <%# <- punctuation.bracket %>
+<%#    ^ module %>
+<%#       ^ module %>
+<%#           ^ module %>
+<%#                ^ module %>
+<%#                   ^ module %>
+<%#                    ^ punctuation.delimiter %>
+<%#                     ^ function %>
+<%#                        ^ function %>
     <% end %>
     <%# here we're intentionally leaving a tag unclosed to trigger the error later on </html>: %>
     <div></div></div>

--- a/test/highlight/main.heex
+++ b/test/highlight/main.heex
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<%# ^ constant %>
+<html>
+<%# <- punctuation.bracket %>
+<%#  ^ punctuation.bracket %>
+  <head>
+  <%# ^ tag %>
+    <%= csrf_meta_tag() %>
+    <%# <- keyword %>
+    <%#                 ^ keyword %>
+    <link phx-track-static rel="stylesheet" src={ Routes.static_path(@conn, "/css/app.css") } />
+    <%# <- punctuation.bracket %>
+    <%# ^ tag %>
+    <%#    ^ attribute %>
+    <%#                     ^ attribute %>
+    <%#                           ^ string %>
+    <%#                                         ^ keyword %>
+    <%#                                                                                     ^ keyword %>
+    <%#                                                                                       ^ punctuation.bracket %>
+  </head>
+  <body>
+    <%= if true do %>
+    <%# <- keyword %>
+    <%#            ^ keyword %>
+      <MyComponents.modal key=value key="value" key={ @value } />
+      <%# <- punctuation.bracket %>
+      <%# ^ module %>
+      <%#                  ^ attribute %>
+      <%#                      ^ string %>
+      <%#                            ^ attribute %>
+      <%#                                 ^ string %>
+      <%#                                        ^ attribute %>
+      <%#                                           ^ keyword %>
+      <%#                                                    ^ keyword %>
+      <%#                                                      ^ punctuation.bracket %>
+      <.form />
+      <%# ^ module %>
+    <% end %>
+    <%# here we're intentionally leaving a tag unclosed to trigger the error later on </html>: %>
+    <div></div></div>
+<%#   ^ tag %>
+<%#         ^ tag %>
+<%#               ^ tag %>
+  </body>
+</html>
+<%# ^ error %>


### PR DESCRIPTION
connects https://github.com/connorlay/tree-sitter-eex/issues/1
connects https://github.com/elixir-lang/tree-sitter-elixir/issues/2

Pretty much the same thing as https://github.com/connorlay/tree-sitter-eex/pull/4 but for the heex directives. I'm open to renaming the new node, naming things is hard :sweat_smile:

With this change to the grammar I'm seeing good combined injections results:

![heex-highlights](https://user-images.githubusercontent.com/21230295/148662502-dac48636-06d2-4d70-a8ad-9d394432dea9.png)

Although the error `->` affects heex as well as eex.

I also slightly modified the queries so that the `<%`, `<%=`, etc. act like keywords like [in tree-sitter-embedded-template](https://github.com/tree-sitter/tree-sitter-embedded-template/blob/d21df11b0ecc6fd211dbe11278e92ef67bd17e97/queries/highlights.scm#L12) or the eex highlight PR. I did like the old scopes for those though; it was nice to have them look subtle. Maybe it makes sense to use `punctuation.directive` so that theme authors can make a distinction but it defaults to looking like otherwise punctuation?