### PR TITLE
Allow hyphens in HTML tag names

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -237,7 +237,7 @@ module.exports = grammar({
 
     _code: $ => /[^%\s]+|[%\s]/,
 
-    tag_name: $ => /[a-z]+[^\-<>{}!"'/=\s]*/,
+    tag_name: $ => /[a-z]+[^<>{}!"'/=\s]*/,
 
     attribute_name: $ => token(prec(-1, /[^<>{}"'/=\s]+/)),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -842,7 +842,7 @@
     },
     "tag_name": {
       "type": "PATTERN",
-      "value": "[a-z]+[^\\-<>{}!\"'/=\\s]*"
+      "value": "[a-z]+[^<>{}!\"'/=\\s]*"
     },
     "attribute_name": {
       "type": "TOKEN",

--- a/src/parser.c
+++ b/src/parser.c
@@ -591,15 +591,13 @@ static inline bool sym_module_character_set_1(int32_t c) {
 }
 
 static inline bool sym_tag_name_character_set_1(int32_t c) {
-  return (c < '-'
+  return (c < '\''
     ? (c < '\r'
       ? (c < '\t'
         ? c == 0
         : c <= '\n')
-      : (c <= '\r' || (c < '\''
-        ? (c >= ' ' && c <= '"')
-        : c <= '\'')))
-    : (c <= '-' || (c < '{'
+      : (c <= '\r' || (c >= ' ' && c <= '"')))
+    : (c <= '\'' || (c < '{'
       ? (c < '<'
         ? c == '/'
         : c <= '>')

--- a/test/corpus/tags.txt
+++ b/test/corpus/tags.txt
@@ -86,3 +86,23 @@ DOCTYPE
         (tag_name)))
     (end_tag
       (tag_name))))
+
+================================================================================
+Tag name with hyphen
+================================================================================
+
+<box-icon name='like'>
+</box-icon>
+
+--------------------------------------------------------------------------------
+
+(fragment
+  (tag
+    (start_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value))))
+    (end_tag
+      (tag_name))))


### PR DESCRIPTION
I did a small test and it looks like the HEEx parser accepts html tags with hyphens. What do you think?

closes #14 