### PR TITLE
Fix link to sigil_H/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tree-sitter HEEx
 
-[Tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar and parser for [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Helpers.html#sigil_H/2), the HTML-aware and component-friendly extension of EEx for [Phoenix](https://www.phoenixframework.org/).
+[Tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar and parser for [HEEx](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2), the HTML-aware and component-friendly extension of EEx for [Phoenix](https://www.phoenixframework.org/).
 
 For EEx support, see [tree-sitter-eex](https://github.com/connorlay/tree-sitter-eex). For Surface support, see [tree-sitter-surface](https://github.com/connorlay/tree-sitter-surface).
 


### PR DESCRIPTION
`sigil_H/2` and the HEEx documentation moved from `Phoenix.LiveView.Helpers` to `Phoenix.Component` in https://github.com/phoenixframework/phoenix_live_view/commit/02e20e4f5a01356004efd7fb965bbeeb99534c35.

With the 0.18.0 release, this left the HEEx link in the README broken. This change points to the new URL.

Closes #25