### PR TITLE
Add support for aliasing HEEx template highlighting for NEEx templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "tree-sitter": [
     {
       "scope": "source.heex",
-      "file-types": ["heex"],
-      "injection-regex": "^(heex)$"
+      "file-types": ["heex", "neex"],
+      "injection-regex": "^(heex|neex)$"
     }
   ]
 }


### PR DESCRIPTION
This allows LiveView Native templates to get syntax highlighting without having to implement our own library. Our templates use the exact same syntax highlighting strategies as HEEx