### PR TITLE
Add syntax highlight support for <script> and <style> tags

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -25,3 +25,28 @@
 ((expression (expression_value) @injection.content)
  (#set! injection.language "elixir")
  (#set! injection.include-children))
+
+; Sintax highlight for style and javascript tags
+((tag
+  (start_tag
+      (tag_name) @tag_name (#eq? @tag_name "script"))
+  (text)
+  (end_tag)
+) @injection.content
+ (#offset! @injection.content 1 0 0 -9)
+ (#set! injection.language "javascript")
+ (#set! injection.include-children)
+ (#set! injection.combined)
+)
+
+((tag
+  (start_tag
+      (tag_name) @tag_name (#eq? @tag_name "style"))
+  (text)
+  (end_tag)
+) @injection.content
+ (#offset! @injection.content 1 0 0 -9)
+ (#set! injection.language "css")
+ (#set! injection.include-children)
+ (#set! injection.combined)
+)


### PR DESCRIPTION
Add syntax highlight support for JavaScript and CSS code inside of <script> and <style> tags.
It doesn't fix the grammar. 
See: #37