### PR TITLE
Update Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-heex"
 description = "heex grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.7.0"
 keywords = ["incremental", "parsing", "heex"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-heex"
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.22.0"
+tree-sitter = "0.22"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
* Loosen tree-sitter dependency version restriction
* Bump package version to match the latest release

This is for the sake of publishing a crate which I just put up here with these changes: https://crates.io/crates/tree-sitter-heex

@connorlay let me know if you have a crates.io username and I'll invite you as an owner. I'll add @jonatanklosko too