### PR TITLE
Update version to v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.1
+- Update tree-sitter version used to generate the grammar and bindings to v0.24.7, thanks @jonatanklosko!
+
 ## 0.7.0
 - Support HEEx expressions `{...}` within the body of a tag, thanks @kevinschweikert and @jonatanklosko!
 - Support NEEx template highlighting, thanks @bcardarella!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-heex
-        VERSION "0.7.0"
+        VERSION "0.7.1"
         DESCRIPTION "Tree-sitter grammar for HEEx files"
         HOMEPAGE_URL "https://github.com/phoenixframework/tree-sitter-heex"
         LANGUAGES C)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-heex"
 description = "heex grammar for the tree-sitter parsing library"
-version = "0.7.0"
+version = "0.7.1"
 keywords = ["incremental", "parsing", "heex"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/phoenixframework/tree-sitter-heex"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 LANGUAGE_NAME := tree-sitter-heex
 HOMEPAGE_URL := https://github.com/phoenixframework/tree-sitter-heex
-VERSION := 0.7.0
+VERSION := 0.7.1
 
 # repository
 SRC_DIR := src

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-heex",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Tree-sitter grammar for HEEx files",
   "main": "bindings/node",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-heex"
 description = "Tree-sitter grammar for HEEx files"
-version = "0.7.0"
+version = "0.7.1"
 keywords = ["incremental", "parsing", "tree-sitter", "heex"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -14,7 +14,7 @@
     }
   ],
   "metadata": {
-    "version": "0.7.0",
+    "version": "0.7.1",
     "license": "MIT",
     "description": "Tree-sitter grammar for HEEx files",
     "authors": [


### PR DESCRIPTION
The `tree-sitter version 0.7.1` command can be used to update all the versions in the bindings. (Should be available in v0.25.0+, not yet released)