### PR TITLE
Remove .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-nodejs lts


### PR DESCRIPTION
This has fallen out of date: the nodejs asdf plugin no longer accepts 'lts'.

I don't have `asdf` set up so I can't test keeping the file but changing the version number. We could set this to the current LTS instead of removing the file.