### PR TITLE
Add mise.toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ For EEx support, see [tree-sitter-eex](https://github.com/connorlay/tree-sitter-
 
 ### Requirements
 * [NodeJS](https://nodejs.org/en/) LTS
-* [`node-gyp-build`](https://www.npmjs.com/package/node-gyp-build)
 * [mise](https://mise.jdx.dev/) (optional)
 * [Docker](https://www.docker.com/) (optional)
 
@@ -26,32 +25,27 @@ cd tree-sitter-heex
 mise install
 ```
 
-3. Install `node-gyp-build` globally:
-```sh
-npm install -g node-gyp-build
-```
-
-4. Install npm dependencies:
+3. Install npm dependencies:
 ```sh
 npm install
 ```
 
-5. Run the tests:
+4. Run the tests:
 ```sh
 npm test
 ```
 
-6. Run the code formatter:
+5. Run the code formatter:
 ```sh
 npm run format
 ```
 
-7. (Optional) Update the tests (useful when contributing):
+6. (Optional) Update the tests (useful when contributing):
 ```sh
 npm run update_test
 ```
 
-8. (Optional) Run the web playground (requires Docker):
+7. (Optional) Run the web playground (requires Docker):
 ```sh
 npm run playground
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For EEx support, see [tree-sitter-eex](https://github.com/connorlay/tree-sitter-
 
 ### Requirements
 * [NodeJS](https://nodejs.org/en/) LTS
-* [asdf](https://asdf-vm.com/) (optional)
+* [mise](https://mise.jdx.dev/) (optional)
 * [Docker](https://www.docker.com/) (optional)
 
 See [Creating Parsers](https://tree-sitter.github.io/tree-sitter/creating-parsers) for more information.
@@ -19,10 +19,10 @@ See [Creating Parsers](https://tree-sitter.github.io/tree-sitter/creating-parser
 git clone https://github.com/phoenixframework/tree-sitter-heex.git
 ```
 
-2. (Optional) Install NodeJS via asdf:
+2. (Optional) Install NodeJS via mise:
 ```sh
 cd tree-sitter-heex
-asdf install
+mise install
 ```
 
 3. Install npm dependencies:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For EEx support, see [tree-sitter-eex](https://github.com/connorlay/tree-sitter-
 
 ### Requirements
 * [NodeJS](https://nodejs.org/en/) LTS
+* [`node-gyp-build`](https://www.npmjs.com/package/node-gyp-build)
 * [mise](https://mise.jdx.dev/) (optional)
 * [Docker](https://www.docker.com/) (optional)
 
@@ -25,27 +26,32 @@ cd tree-sitter-heex
 mise install
 ```
 
-3. Install npm dependencies:
+3. Install `node-gyp-build` globally:
+```sh
+npm install -g node-gyp-build
+```
+
+4. Install npm dependencies:
 ```sh
 npm install
 ```
 
-4. Run the tests:
+5. Run the tests:
 ```sh
 npm test
 ```
 
-5. Run the code formatter:
+6. Run the code formatter:
 ```sh
 npm run format
 ```
 
-6. (Optional) Update the tests (useful when contributing):
+7. (Optional) Update the tests (useful when contributing):
 ```sh
 npm run update_test
 ```
 
-7. (Optional) Run the web playground (requires Docker):
+8. (Optional) Run the web playground (requires Docker):
 ```sh
 npm run playground
 ```

--- a/README.md
+++ b/README.md
@@ -60,5 +60,6 @@ See [Using Parsers](https://tree-sitter.github.io/tree-sitter/using-parsers) for
 
 ## Editor Support
 
-* [neovim](https://neovim.io/) via [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
-* [helix](https://helix-editor.com/)
+* [Neovim](https://neovim.io/) via [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+* [Helix](https://helix-editor.com/)
+* [Zed](https://zed.dev/) via the [Elixir extension](https://zed.dev/extensions/elixir)

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+node = "lts"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "node-addon-api": "^7.1.0",
-    "node-gyp-build": "^4.8.0"
+    "node-gyp-build": "^4.8.4"
   },
   "devDependencies": {
     "prettier": "^2.7.1",


### PR DESCRIPTION
This replaces the old asdf instructions with ones for mise; the `.tool-versions` file needed to install NodeJS with asdf was removed because the NodeJS asdf plugin no longer accepts `lts` as a version identifier, but mise still does